### PR TITLE
fix: plugin review issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
 	"files": [
 		"build/*",
 		"includes/*",
+		"languages/*",
 		"vendor/*",
+		"composer.json",
+		"composer.lock",
 		"LICENSE.md",
 		"README.md",
 		"readme.txt",

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Vinyl ===
-Contributors:      bitmachin, codekraft
+Contributors:      bitmachina, codekraft
 Tags:              audio, block, playlist, player, sound
 Requires at least: 6.2
 Tested up to:      6.4
 Requires PHP:      7.4
-Stable tag:        0.1.1
-License:           GPL-2.0-or-later
+Stable tag:        0.1.2
+License:           GPL v2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
 Vinyl is a audio player plugin.
@@ -29,7 +29,17 @@ improving the user experience.
 * WordPress 6.2 or greater
 * PHP version 7.4 or greater
 
+== Source Code ==
+
+The source code for this plugin is available on [GitHub](https://github.com/wp-blocks/vinyl).
+
+This plugin is uses the library [media-chrome](https://github.com/muxinc/media-chrome) to render
+the audio player.
+
 == Changelog ==
+
+= 0.1.2: April 29th, 2024 =
+* Fix plugin review issues. Add source code link and update the readme.txt to match the plugin header.
 
 = 0.1.1: March 5th, 2024 =
 * Fixed readme and plugin header to match the plugin name.

--- a/vinyl.php
+++ b/vinyl.php
@@ -3,12 +3,12 @@
  * Plugin Name:       Vinyl Audio
  * Plugin URI:        https://github.com/wp-blocks/vinyl
  * Description:       An advanced WordPress audio player.
- * Version:           0.1.1
+ * Version:           0.1.2
  * Requires at least: 6.2
  * Requires PHP:      7.4
  * Author:            codekraft, bitmachina
  * Author URI:        https://github.com/wp-blocks
- * License: GPL       v2 or later
+ * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       vinyl
  * Domain Path:       /languages


### PR DESCRIPTION
- Update the `readme.txt` to include the same license wording as the plugin header.
- Include the `composer.json` file in the plugin zip.
- Include a link to the source code in the `readme.txt`.

Fixes #4