### PR TITLE
fix: improve mobile styling

### DIFF
--- a/src/audio/player/player.tsx
+++ b/src/audio/player/player.tsx
@@ -20,14 +20,20 @@ export default function Player({ loop, preload, src }: Props) {
 		<MediaController audio={true} autohide="-1" className="vinyl__player">
 			<audio slot="media" src={src} preload={preload} loop={loop} />
 			<MediaControlBar className="vinyl__control-bar">
-				<MediaPlayButton></MediaPlayButton>
-				<MediaSeekBackwardButton></MediaSeekBackwardButton>
-				<MediaSeekForwardButton></MediaSeekForwardButton>
-				<MediaTimeRange></MediaTimeRange>
-				<MediaTimeDisplay showDuration></MediaTimeDisplay>
-				<MediaPlaybackRateButton></MediaPlaybackRateButton>
-				<MediaMuteButton></MediaMuteButton>
-				<MediaVolumeRange></MediaVolumeRange>
+				<div className="vinyl__media-controls">
+					<MediaPlayButton></MediaPlayButton>
+					<MediaSeekBackwardButton></MediaSeekBackwardButton>
+					<MediaSeekForwardButton></MediaSeekForwardButton>
+				</div>
+				<div className="vinyl__media-range">
+					<MediaTimeRange></MediaTimeRange>
+					<MediaTimeDisplay showDuration></MediaTimeDisplay>
+				</div>
+				<div className="vinyl__media-sound">
+					<MediaPlaybackRateButton></MediaPlaybackRateButton>
+					<MediaMuteButton></MediaMuteButton>
+					<MediaVolumeRange></MediaVolumeRange>
+				</div>
 			</MediaControlBar>
 		</MediaController>
 	);

--- a/src/audio/save.tsx
+++ b/src/audio/save.tsx
@@ -33,14 +33,20 @@ export default function Save({ attributes }: BlockSaveProps<Attributes>) {
 						loop={loop}
 					/>
 					<MediaControlBar className="vinyl__control-bar">
-						<MediaPlayButton></MediaPlayButton>
-						<MediaSeekBackwardButton></MediaSeekBackwardButton>
-						<MediaSeekForwardButton></MediaSeekForwardButton>
-						<MediaTimeRange></MediaTimeRange>
-						<MediaTimeDisplay showDuration></MediaTimeDisplay>
-						<MediaPlaybackRateButton></MediaPlaybackRateButton>
-						<MediaMuteButton></MediaMuteButton>
-						<MediaVolumeRange></MediaVolumeRange>
+						<div className="vinyl__media-controls">
+							<MediaPlayButton></MediaPlayButton>
+							<MediaSeekBackwardButton></MediaSeekBackwardButton>
+							<MediaSeekForwardButton></MediaSeekForwardButton>
+						</div>
+						<div className="vinyl__media-range">
+							<MediaTimeRange></MediaTimeRange>
+							<MediaTimeDisplay showDuration></MediaTimeDisplay>
+						</div>
+						<div className="vinyl__media-sound">
+							<MediaPlaybackRateButton></MediaPlaybackRateButton>
+							<MediaMuteButton></MediaMuteButton>
+							<MediaVolumeRange></MediaVolumeRange>
+						</div>
 					</MediaControlBar>
 				</MediaController>
 				{hasCaption(attributes) && (

--- a/src/audio/style.scss
+++ b/src/audio/style.scss
@@ -15,13 +15,66 @@
 	.vinyl__player {
 		width: 100%;
 		/* Prevent layout shift from before the media controls render. */
-		height: 44px;
+		min-height: 44px;
 		/* The browser natively applies a 300px width to the audio block. */
 		/* We restore this as a min-width instead, for alignments. */
 		min-width: 300px;
 	}
 
 	.vinyl__control-bar {
-		width: 100%;
+		display: grid;
+		grid-template-rows: [start top] auto [top bottom] auto [bottom end];
+		grid-template-columns: [start controls] 1fr [controls sound] auto [sound end];
+		align-items: center;
+
+		@media (min-width: 650px) {
+			grid-template-columns: [start controls] auto [controls range] 1fr [range sound] auto [sound end];
+			grid-template-rows: 1fr;
+			grid-column: range / range;
+		}
+	}
+
+	.vinyl__media-range {
+		grid-row: top / top;
+		grid-column: start / end;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		media-time-range {
+			width: 100%;
+		}
+
+		@media (min-width: 650px) {
+			grid-column: range / range;
+			grid-row: 1;
+		}
+	}
+
+	.vinyl__media-controls {
+		grid-column: controls / controls;
+		grid-row: bottom / bottom;
+		display: flex;
+		align-items: flex-end;
+
+		@media (min-width: 650px) {
+			grid-column: controls / controls;
+			grid-row: 1;
+			align-items: center;
+		}
+	}
+
+	.vinyl__media-sound {
+		grid-column: sound / sound;
+		grid-row: bottom / bottom;
+		display: flex;
+		justify-content: flex-end;
+		align-items: flex-end;
+
+		@media (min-width: 650px) {
+			grid-column: sound / sound;
+			grid-row: 1;
+			align-items: center;
+		}
 	}
 }


### PR DESCRIPTION
Use grid layout with named grid lines to separate the player track and controls on mobile.

<img width="385" alt="fix-issue-6-mobile-styling" src="https://github.com/wp-blocks/vinyl/assets/20690965/a9413882-e31f-432e-8d5b-8e4acf22d03e">

Fixes #6