### PR TITLE
chore: update media-chrome to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,26 +7,26 @@
 			"name": "@wp-blocks/vinyl",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/icons": "^9.43.0",
+				"@wordpress/icons": "^9.26.3",
 				"classnames": "^2.5.1",
-				"media-chrome": "^2.2.5"
+				"media-chrome": "^3.2.1"
 			},
 			"devDependencies": {
-				"@types/react": "^18.2.58",
-				"@types/react-dom": "^18.2.19",
-				"@types/wordpress__block-editor": "^11.5.10",
-				"@types/wordpress__blocks": "^12.5.13",
-				"@wordpress/block-editor": "^11.3.11",
-				"@wordpress/block-library": "^8.3.14",
-				"@wordpress/blocks": "^12.3.4",
-				"@wordpress/components": "^23.3.8",
-				"@wordpress/data": "^8.3.4",
-				"@wordpress/element": "^5.3.3",
-				"@wordpress/eslint-plugin": "^17.9.0",
-				"@wordpress/notices": "^3.26.4",
-				"@wordpress/prettier-config": "^3.9.0",
-				"@wordpress/scripts": "^27.3.0",
-				"@wordpress/stylelint-config": "^21.35.0",
+				"@types/react": "^18.3.1",
+				"@types/react-dom": "^18.3.0",
+				"@types/wordpress__block-editor": "^11.5.14",
+				"@types/wordpress__blocks": "^12.5.14",
+				"@wordpress/block-editor": "^12.3.15",
+				"@wordpress/block-library": "^8.12.19",
+				"@wordpress/blocks": "^12.12.8",
+				"@wordpress/components": "^25.1.12",
+				"@wordpress/data": "^9.5.6",
+				"@wordpress/element": "^5.12.2",
+				"@wordpress/eslint-plugin": "^17.13.0",
+				"@wordpress/notices": "^4.3.6",
+				"@wordpress/prettier-config": "^3.13.0",
+				"@wordpress/scripts": "^27.7.0",
+				"@wordpress/stylelint-config": "^21.39.0",
 				"@wp-blocks/make-pot": "^1.2.0",
 				"@wp-blocks/tsconfig": "^0.1.0",
 				"eslint": "^8.57.0",
@@ -35,10 +35,10 @@
 				"husky": "^9.0.11",
 				"lint-staged": "^15.2.2",
 				"prettier": "^3.2.5",
-				"react": "^18.2.0",
-				"react-dom": "^18.2.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1",
 				"stylelint": "^14.16.1",
-				"typescript": "^5.3.3"
+				"typescript": "^5.4.5"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -186,9 +186,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-			"integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+			"integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -307,19 +307,19 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.23.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.10.tgz",
-			"integrity": "sha512-2XpP2XhkXzgxecPNEEK8Vz8Asj9aRxt08oKOqtiZoqV2UGZ5T+EkyP9sXQ9nwMxBIG34a7jmasVqoMop7VdPUw==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.5.tgz",
+			"integrity": "sha512-uRc4Cv8UQWnE4NXlYTIIdM7wfFkOqlFztcC/gVXDKohKoVB3OyonfelUBaJzSwpBntZ2KYGF/9S7asCHsXwW6g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-member-expression-to-functions": "^7.23.0",
+				"@babel/helper-member-expression-to-functions": "^7.24.5",
 				"@babel/helper-optimise-call-expression": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.20",
+				"@babel/helper-replace-supers": "^7.24.1",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-split-export-declaration": "^7.24.5",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -347,9 +347,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz",
-			"integrity": "sha512-NovQquuQLAQ5HuyjCz7WQP9MjRj7dx++yspwiyUiGl9ZyadHRSql1HZh5ogRd8W8w6YM6EQ/NTB8rgjLt5W65Q==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
+			"integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.22.6",
@@ -397,24 +397,24 @@
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
-			"integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.5.tgz",
+			"integrity": "sha512-4owRteeihKWKamtqg4JmWSsEZU445xpFRXPEwp44HbgbxdWlUV1b4Agg4lkA806Lil5XM/e+FJyS0vj5T6vmcA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.23.0"
+				"@babel/types": "^7.24.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+			"integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.15"
+				"@babel/types": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -452,9 +452,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+			"integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -478,13 +478,13 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
-			"integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.1.tgz",
+			"integrity": "sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-member-expression-to-functions": "^7.22.15",
+				"@babel/helper-member-expression-to-functions": "^7.23.0",
 				"@babel/helper-optimise-call-expression": "^7.22.5"
 			},
 			"engines": {
@@ -519,30 +519,30 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+			"integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.24.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+			"integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -558,14 +558,14 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
-			"integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.5.tgz",
+			"integrity": "sha512-/xxzuNvgRl4/HLNKvnFwdhdgN3cpLxgLROeLDl83Yx0AJ1SGvq1ak0OszTOjDfiB8Vx03eJbeDWh9r+jCCWttw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-function-name": "^7.22.5",
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.22.19"
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/template": "^7.24.0",
+				"@babel/types": "^7.24.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -682,13 +682,29 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.23.3.tgz",
-			"integrity": "sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==",
+		"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.5.tgz",
+			"integrity": "sha512-LdXRi1wEMTrHVR4Zc9F8OewC3vdm5h4QB6L71zy6StmYeqGi1b3ttIO8UC+BfZKcH9jdr4aI249rBkm+3+YvHw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-plugin-utils": "^7.24.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.1.tgz",
+			"integrity": "sha512-y4HqEnkelJIOQGd+3g1bTeKsA5c6qM7eOn7VggGVbBc0y8MLSKHacwcIE2PplNlQSj0PqS9rrXL/nkPVK+kUNg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -698,14 +714,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.23.3.tgz",
-			"integrity": "sha512-WwlxbfMNdVEpQjZmK5mhm7oSwD3dS6eU+Iwsi4Knl9wAletWem7kaRsGOG+8UEbRyqxY4SS5zvtfXwX+jMxUwQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.1.tgz",
+			"integrity": "sha512-Hj791Ii4ci8HqnaKHAlLNs+zaLXb0EzSDhiAWp5VNlyvCNymYfacs64pxTxbH1znW/NcArSmwpmG9IKE/TUVVQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-				"@babel/plugin-transform-optional-chaining": "^7.23.3"
+				"@babel/plugin-transform-optional-chaining": "^7.24.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -715,13 +731,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.7.tgz",
-			"integrity": "sha512-LlRT7HgaifEpQA1ZgLVOIJZZFVPWN5iReq/7/JixwBtwcoeVGDBD53ZV28rrsLYOZs1Y/EHhA8N/Z6aazHR8cw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.1.tgz",
+			"integrity": "sha512-m9m/fXsXLiHfwdgydIFnpk+7jlVbnvlK5B2EKiPdLUb6WX654ZaaEWJUjk8TftRbZpK0XibovlLWX4KIZhV6jw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -818,12 +834,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.23.3.tgz",
-			"integrity": "sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.1.tgz",
+			"integrity": "sha512-IuwnI5XnuF189t91XbxmXeCDz3qs6iDRO7GJ++wcfgeXNs/8FmIlKcpDSXNVyuLQxlwvskmI3Ct73wUODkJBlQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -833,12 +849,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.23.3.tgz",
-			"integrity": "sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.1.tgz",
+			"integrity": "sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -872,12 +888,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
-			"integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
+			"integrity": "sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -989,12 +1005,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
-			"integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
+			"integrity": "sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1020,12 +1036,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-arrow-functions": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.23.3.tgz",
-			"integrity": "sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.1.tgz",
+			"integrity": "sha512-ngT/3NkRhsaep9ck9uj2Xhv9+xB1zShY3tM3g6om4xxCELwCDN4g4Aq5dRn48+0hasAql7s2hdBOysCfNpr4fw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1035,13 +1051,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
-			"integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.3.tgz",
+			"integrity": "sha512-Qe26CMYVjpQxJ8zxM1340JFNjZaF+ISWpr1Kt/jGo+ZTUzKkfw/pphEWbRCb+lmSM6k/TOgfYLvmbHkUQ0asIg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-remap-async-to-generator": "^7.22.20",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			},
@@ -1053,13 +1069,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.23.3.tgz",
-			"integrity": "sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.1.tgz",
+			"integrity": "sha512-AawPptitRXp1y0n4ilKcGbRYWfbbzFWz2NqNu7dacYDtFtz0CMjG64b3LQsb3KIgnf4/obcUL78hfaOS7iCUfw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-module-imports": "^7.24.1",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-remap-async-to-generator": "^7.22.20"
 			},
 			"engines": {
@@ -1070,12 +1086,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.23.3.tgz",
-			"integrity": "sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.1.tgz",
+			"integrity": "sha512-TWWC18OShZutrv9C6mye1xwtam+uNi2bnTOCBUd5sZxyHOiWbU6ztSROofIMrK84uweEZC219POICK/sTYwfgg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1085,12 +1101,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.4.tgz",
-			"integrity": "sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.5.tgz",
+			"integrity": "sha512-sMfBc3OxghjC95BkYrYocHL3NaOplrcaunblzwXhGmlPwpmfsxr4vK+mBBt49r+S240vahmv+kUxkeKgs+haCw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1100,13 +1116,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.23.3.tgz",
-			"integrity": "sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.1.tgz",
+			"integrity": "sha512-OMLCXi0NqvJfORTaPQBwqLXHhb93wkBKZ4aNwMl6WtehO7ar+cmp+89iPEQPqxAnxsOKTaMcs3POz3rKayJ72g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-class-features-plugin": "^7.24.1",
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1116,13 +1132,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
-			"integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.4.tgz",
+			"integrity": "sha512-B8q7Pz870Hz/q9UgP8InNpY01CSLDSCyqX7zcRuv3FcPl87A2G17lASroHWaCtbdIcbYzOZ7kWmXFKbijMSmFg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-create-class-features-plugin": "^7.24.4",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			},
 			"engines": {
@@ -1133,18 +1149,18 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
-			"integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.5.tgz",
+			"integrity": "sha512-gWkLP25DFj2dwe9Ck8uwMOpko4YsqyfZJrOmqqcegeDYEbp7rmn4U6UQZNj08UF6MaX39XenSpKRCvpDRBtZ7Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.20",
-				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-plugin-utils": "^7.24.5",
+				"@babel/helper-replace-supers": "^7.24.1",
+				"@babel/helper-split-export-declaration": "^7.24.5",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -1155,13 +1171,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.23.3.tgz",
-			"integrity": "sha512-dTj83UVTLw/+nbiHqQSFdwO9CbTtwq1DsDqm3CUEtDrZNET5rT5E6bIdTlOftDTDLMYxvxHNEYO4B9SLl8SLZw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.1.tgz",
+			"integrity": "sha512-5pJGVIUfJpOS+pAqBQd+QMaTD2vCL/HcePooON6pDpHgRp4gNRmzyHTPIkXntwKsq3ayUFVfJaIKPw2pOkOcTw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/template": "^7.22.15"
+				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/template": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1171,12 +1187,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.3.tgz",
-			"integrity": "sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.5.tgz",
+			"integrity": "sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1186,13 +1202,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.23.3.tgz",
-			"integrity": "sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.1.tgz",
+			"integrity": "sha512-p7uUxgSoZwZ2lPNMzUkqCts3xlp8n+o05ikjy7gbtFJSt9gdU88jAmtfmOxHM14noQXBxfgzf2yRWECiNVhTCw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1202,12 +1218,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-keys": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.23.3.tgz",
-			"integrity": "sha512-RrqQ+BQmU3Oyav3J+7/myfvRCq7Tbz+kKLLshUmMwNlDHExbGL7ARhajvoBJEvc+fCguPPu887N+3RRXBVKZUA==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.1.tgz",
+			"integrity": "sha512-msyzuUnvsjsaSaocV6L7ErfNsa5nDWL1XKNnDePLgmz+WdU4w/J8+AxBMrWfi9m4IxfL5sZQKUPQKDQeeAT6lA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1217,12 +1233,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dynamic-import": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.4.tgz",
-			"integrity": "sha512-V6jIbLhdJK86MaLh4Jpghi8ho5fGzt3imHOBu/x0jlBaPYqDoWz4RDXjmMOfnh+JWNaQleEAByZLV0QzBT4YQQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.1.tgz",
+			"integrity": "sha512-av2gdSTyXcJVdI+8aFZsCAtR29xJt0S5tas+Ef8NvBNmD1a+N/3ecMLeMBgfcK+xzsjdLDT6oHt+DFPyeqUbDA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3"
 			},
 			"engines": {
@@ -1233,13 +1249,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.23.3.tgz",
-			"integrity": "sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.1.tgz",
+			"integrity": "sha512-U1yX13dVBSwS23DEAqU+Z/PkwE9/m7QQy8Y9/+Tdb8UWYaGNDYwTLi19wqIAiROr8sXVum9A/rtiH5H0boUcTw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1249,12 +1265,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-export-namespace-from": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.4.tgz",
-			"integrity": "sha512-GzuSBcKkx62dGzZI1WVgTWvkkz84FZO5TC5T8dl/Tht/rAla6Dg/Mz9Yhypg+ezVACf/rgDuQt3kbWEv7LdUDQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.24.1.tgz",
+			"integrity": "sha512-Ft38m/KFOyzKw2UaJFkWG9QnHPG/Q/2SkOrRk4pNBPg5IPZ+dOxcmkK5IyuBcxiNPyyYowPGUReyBvrvZs7IlQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
 			},
 			"engines": {
@@ -1265,12 +1281,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
-			"integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.1.tgz",
+			"integrity": "sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
 			},
 			"engines": {
@@ -1281,14 +1297,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.23.3.tgz",
-			"integrity": "sha512-I1QXp1LxIvt8yLaib49dRW5Okt7Q4oaxao6tFVKS/anCdEOMtYwWVKoiOA1p34GOWIZjUK0E+zCp7+l1pfQyiw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.1.tgz",
+			"integrity": "sha512-BXmDZpPlh7jwicKArQASrj8n22/w6iymRnvHYYd2zO30DbE277JO20/7yXJT3QxDPtiQiOxQBbZH4TpivNXIxA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1298,12 +1314,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.4.tgz",
-			"integrity": "sha512-81nTOqM1dMwZ/aRXQ59zVubN9wHGqk6UtqRK+/q+ciXmRy8fSolhGVvG09HHRGo4l6fr/c4ZhXUQH0uFW7PZbg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.1.tgz",
+			"integrity": "sha512-U7RMFmRvoasscrIFy5xA4gIp8iWnWubnKkKuUGJjsuOH7GfbMkB+XZzeslx2kLdEGdOJDamEmCqOks6e8nv8DQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-json-strings": "^7.8.3"
 			},
 			"engines": {
@@ -1314,12 +1330,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.23.3.tgz",
-			"integrity": "sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.1.tgz",
+			"integrity": "sha512-zn9pwz8U7nCqOYIiBaOxoQOtYmMODXTJnkxG4AtX8fPmnCRYWBOHD0qcpwS9e2VDSp1zNJYpdnFMIKb8jmwu6g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1329,12 +1345,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.4.tgz",
-			"integrity": "sha512-Mc/ALf1rmZTP4JKKEhUwiORU+vcfarFVLfcFiolKUo6sewoxSEgl36ak5t+4WamRsNr6nzjZXQjM35WsU+9vbg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.1.tgz",
+			"integrity": "sha512-OhN6J4Bpz+hIBqItTeWJujDOfNP+unqv/NJgyhlpSqgBTPm37KkMmZV6SYcOj+pnDbdcl1qRGV/ZiIjX9Iy34w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
 			},
 			"engines": {
@@ -1345,12 +1361,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-member-expression-literals": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.23.3.tgz",
-			"integrity": "sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.1.tgz",
+			"integrity": "sha512-4ojai0KysTWXzHseJKa1XPNXKRbuUrhkOPY4rEGeR+7ChlJVKxFa3H3Bz+7tWaGKgJAXUWKOGmltN+u9B3+CVg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1360,13 +1376,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-amd": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.3.tgz",
-			"integrity": "sha512-vJYQGxeKM4t8hYCKVBlZX/gtIY2I7mRGFNcm85sgXGMTBcoV3QdVtdpbcWEbzbfUIUZKwvgFT82mRvaQIebZzw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.1.tgz",
+			"integrity": "sha512-lAxNHi4HVtjnHd5Rxg3D5t99Xm6H7b04hUS7EHIXcUl2EV4yl1gWdqZrNzXnSrHveL9qMdbODlLF55mvgjAfaQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1376,13 +1392,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
-			"integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.1.tgz",
+			"integrity": "sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-simple-access": "^7.22.5"
 			},
 			"engines": {
@@ -1393,14 +1409,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
-			"integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.1.tgz",
+			"integrity": "sha512-mqQ3Zh9vFO1Tpmlt8QPnbwGHzNz3lpNEMxQb1kAemn/erstyqw1r9KeOlOfo3y6xAnFEcOv2tSyrXfmMk+/YZA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-validator-identifier": "^7.22.20"
 			},
 			"engines": {
@@ -1411,13 +1427,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-umd": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.23.3.tgz",
-			"integrity": "sha512-zHsy9iXX2nIsCBFPud3jKn1IRPWg3Ing1qOZgeKV39m1ZgIdpJqvlWVeiHBZC6ITRG0MfskhYe9cLgntfSFPIg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.1.tgz",
+			"integrity": "sha512-tuA3lpPj+5ITfcCluy6nWonSL7RvaG0AOTeAuvXqEKS34lnLzXpDb0dcP6K8jD0zWZFNDVly90AGFJPnm4fOYg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1443,12 +1459,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-new-target": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.23.3.tgz",
-			"integrity": "sha512-YJ3xKqtJMAT5/TIZnpAR3I+K+WaDowYbN3xyxI8zxx/Gsypwf9B9h0VB+1Nh6ACAAPRS5NSRje0uVv5i79HYGQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.1.tgz",
+			"integrity": "sha512-/rurytBM34hYy0HKZQyA0nHbQgQNFm4Q/BOc9Hflxi2X3twRof7NaE5W46j4kQitm7SvACVRXsa6N/tSZxvPug==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1458,12 +1474,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.4.tgz",
-			"integrity": "sha512-jHE9EVVqHKAQx+VePv5LLGHjmHSJR76vawFPTdlxR/LVJPfOEGxREQwQfjuZEOPTwG92X3LINSh3M40Rv4zpVA==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.1.tgz",
+			"integrity": "sha512-iQ+caew8wRrhCikO5DrUYx0mrmdhkaELgFa+7baMcVuhxIkN7oxt06CZ51D65ugIb1UWRQ8oQe+HXAVM6qHFjw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
 			},
 			"engines": {
@@ -1474,12 +1490,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.4.tgz",
-			"integrity": "sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.1.tgz",
+			"integrity": "sha512-7GAsGlK4cNL2OExJH1DzmDeKnRv/LXq0eLUSvudrehVA5Rgg4bIrqEUW29FbKMBRT0ztSqisv7kjP+XIC4ZMNw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
 			},
 			"engines": {
@@ -1490,16 +1506,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
-			"integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.5.tgz",
+			"integrity": "sha512-7EauQHszLGM3ay7a161tTQH7fj+3vVM/gThlz5HpFtnygTxjrlvoeq7MPVA1Vy9Q555OB8SnAOsMkLShNkkrHA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.23.3",
-				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-plugin-utils": "^7.24.5",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.23.3"
+				"@babel/plugin-transform-parameters": "^7.24.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1509,13 +1524,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-super": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.23.3.tgz",
-			"integrity": "sha512-BwQ8q0x2JG+3lxCVFohg+KbQM7plfpBwThdW9A6TMtWwLsbDA01Ek2Zb/AgDN39BiZsExm4qrXxjk+P1/fzGrA==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.1.tgz",
+			"integrity": "sha512-oKJqR3TeI5hSLRxudMjFQ9re9fBVUU0GICqM3J1mi8MqlhVr6hC/ZN4ttAyMuQR6EZZIY6h/exe5swqGNNIkWQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.20"
+				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-replace-supers": "^7.24.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1525,12 +1540,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.4.tgz",
-			"integrity": "sha512-XIq8t0rJPHf6Wvmbn9nFxU6ao4c7WhghTR5WyV8SrJfUFzyxhCm4nhC+iAp3HFhbAKLfYpgzhJ6t4XCtVwqO5A==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.1.tgz",
+			"integrity": "sha512-oBTH7oURV4Y+3EUrf6cWn1OHio3qG/PVwO5J03iSJmBg6m2EhKjkAu/xuaXaYwWW9miYtvbWv4LNf0AmR43LUA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
 			},
 			"engines": {
@@ -1541,12 +1556,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz",
-			"integrity": "sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.5.tgz",
+			"integrity": "sha512-xWCkmwKT+ihmA6l7SSTpk8e4qQl/274iNbSKRRS8mpqFR32ksy36+a+LWY8OXCCEefF8WFlnOHVsaDI2231wBg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.5",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
 			},
@@ -1558,12 +1573,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz",
-			"integrity": "sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.5.tgz",
+			"integrity": "sha512-9Co00MqZ2aoky+4j2jhofErthm6QVLKbpQrvz20c3CH9KQCLHyNB+t2ya4/UrRpQGR+Wrwjg9foopoeSdnHOkA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1573,13 +1588,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.23.3.tgz",
-			"integrity": "sha512-UzqRcRtWsDMTLrRWFvUBDwmw06tCQH9Rl1uAjfh6ijMSmGYQ+fpdB+cnqRC8EMh5tuuxSv0/TejGL+7vyj+50g==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.1.tgz",
+			"integrity": "sha512-tGvisebwBO5em4PaYNqt4fkw56K2VALsAbAakY0FjTYqJp7gfdrgr7YX76Or8/cpik0W6+tj3rZ0uHU9Oil4tw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-class-features-plugin": "^7.24.1",
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1589,14 +1604,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.4.tgz",
-			"integrity": "sha512-9G3K1YqTq3F4Vt88Djx1UZ79PDyj+yKRnUy7cZGSMe+a7jkwD259uKKuUzQlPkGam7R+8RJwh5z4xO27fA1o2A==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.5.tgz",
+			"integrity": "sha512-JM4MHZqnWR04jPMujQDTBVRnqxpLLpx2tkn7iPn+Hmsc0Gnb79yvRWOkvqFOx3Z7P7VxiRIR22c4eGSNj87OBQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-create-class-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-create-class-features-plugin": "^7.24.5",
+				"@babel/helper-plugin-utils": "^7.24.5",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
 			},
 			"engines": {
@@ -1607,12 +1622,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-property-literals": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.23.3.tgz",
-			"integrity": "sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.1.tgz",
+			"integrity": "sha512-LetvD7CrHmEx0G442gOomRr66d7q8HzzGGr4PMHGr+5YIm6++Yke+jxj246rpvsbyhJwCLxcTn6zW1P1BSenqA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1622,12 +1637,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-constant-elements": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.23.3.tgz",
-			"integrity": "sha512-zP0QKq/p6O42OL94udMgSfKXyse4RyJ0JqbQ34zDAONWjyrEsghYEyTSK5FIpmXmCpB55SHokL1cRRKHv8L2Qw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.1.tgz",
+			"integrity": "sha512-QXp1U9x0R7tkiGB0FOk8o74jhnap0FlZ5gNkRIWdG3eP+SvMFg118e1zaWewDzgABb106QSKpVsD3Wgd8t6ifA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1637,12 +1652,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-display-name": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.23.3.tgz",
-			"integrity": "sha512-GnvhtVfA2OAtzdX58FJxU19rhoGeQzyVndw3GgtdECQvQFXPEZIOVULHVZGAYmOgmqjXpVpfocAbSjh99V/Fqw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.1.tgz",
+			"integrity": "sha512-mvoQg2f9p2qlpDQRBC7M3c3XTr0k7cp/0+kFKKO/7Gtu0LSw16eKB+Fabe2bDT/UpsyasTBBkAnbdsLrkD5XMw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1686,13 +1701,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-pure-annotations": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.23.3.tgz",
-			"integrity": "sha512-qMFdSS+TUhB7Q/3HVPnEdYJDQIk57jkntAwSuz9xfSE4n+3I+vHYCli3HoHawN1Z3RfCz/y1zXA/JXjG6cVImQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.24.1.tgz",
+			"integrity": "sha512-+pWEAaDJvSm9aFvJNpLiM2+ktl2Sn2U5DdyiWdZBxmLc6+xGt88dvFqsHiAiDS+8WqUwbDfkKz9jRxK3M0k+kA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1702,12 +1717,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.23.3.tgz",
-			"integrity": "sha512-KP+75h0KghBMcVpuKisx3XTu9Ncut8Q8TuvGO4IhY+9D5DFEckQefOuIsB/gQ2tG71lCke4NMrtIPS8pOj18BQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.1.tgz",
+			"integrity": "sha512-sJwZBCzIBE4t+5Q4IGLaaun5ExVMRY0lYwos/jNecjMrVCygCdph3IKv0tkP5Fc87e/1+bebAmEAGBfnRD+cnw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"regenerator-transform": "^0.15.2"
 			},
 			"engines": {
@@ -1718,12 +1733,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-reserved-words": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.23.3.tgz",
-			"integrity": "sha512-QnNTazY54YqgGxwIexMZva9gqbPa15t/x9VS+0fsEFWplwVpXYZivtgl43Z1vMpc1bdPP2PP8siFeVcnFvA3Cg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.1.tgz",
+			"integrity": "sha512-JAclqStUfIwKN15HrsQADFgeZt+wexNQ0uLhuqvqAUFoqPMjEcFCYZBhq0LUdz6dZK/mD+rErhW71fbx8RYElg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1733,16 +1748,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.9.tgz",
-			"integrity": "sha512-A7clW3a0aSjm3ONU9o2HAILSegJCYlEZmOhmBRReVtIpY/Z/p7yIZ+wR41Z+UipwdGuqwtID/V/dOdZXjwi9gQ==",
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.3.tgz",
+			"integrity": "sha512-J0BuRPNlNqlMTRJ72eVptpt9VcInbxO6iP3jaxr+1NPhC0UkKL+6oeX6VXMEYdADnuqmMmsBspt4d5w8Y/TCbQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"babel-plugin-polyfill-corejs2": "^0.4.8",
-				"babel-plugin-polyfill-corejs3": "^0.9.0",
-				"babel-plugin-polyfill-regenerator": "^0.5.5",
+				"@babel/helper-module-imports": "^7.24.3",
+				"@babel/helper-plugin-utils": "^7.24.0",
+				"babel-plugin-polyfill-corejs2": "^0.4.10",
+				"babel-plugin-polyfill-corejs3": "^0.10.1",
+				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1753,12 +1768,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-shorthand-properties": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.23.3.tgz",
-			"integrity": "sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.1.tgz",
+			"integrity": "sha512-LyjVB1nsJ6gTTUKRjRWx9C1s9hE7dLfP/knKdrfeH9UPtAGjYGgxIbFfx7xyLIEWs7Xe1Gnf8EWiUqfjLhInZA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1768,12 +1783,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.23.3.tgz",
-			"integrity": "sha512-VvfVYlrlBVu+77xVTOAoxQ6mZbnIq5FM0aGBSFEcIh03qHf+zNqA4DC/3XMUozTg7bZV3e3mZQ0i13VB6v5yUg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.1.tgz",
+			"integrity": "sha512-KjmcIM+fxgY+KxPVbjelJC6hrH1CgtPmTvdXAfn3/a9CnWGSTY7nH4zm5+cjmWJybdcPSsD0++QssDsjcpe47g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
 			},
 			"engines": {
@@ -1784,12 +1799,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-sticky-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.23.3.tgz",
-			"integrity": "sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.1.tgz",
+			"integrity": "sha512-9v0f1bRXgPVcPrngOQvLXeGNNVLc8UjMVfebo9ka0WF3/7+aVUHmaJVT3sa0XCzEFioPfPHZiOcYG9qOsH63cw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1799,12 +1814,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.23.3.tgz",
-			"integrity": "sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.1.tgz",
+			"integrity": "sha512-WRkhROsNzriarqECASCNu/nojeXCDTE/F2HmRgOzi7NGvyfYGq1NEjKBK3ckLfRgGc6/lPAqP0vDOSw3YtG34g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1814,12 +1829,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.23.3.tgz",
-			"integrity": "sha512-4t15ViVnaFdrPC74be1gXBSMzXk3B4Us9lP7uLRQHTFpV5Dvt33pn+2MyyNxmN3VTTm3oTrZVMUmuw3oBnQ2oQ==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.5.tgz",
+			"integrity": "sha512-UTGnhYVZtTAjdwOTzT+sCyXmTn8AhaxOS/MjG9REclZ6ULHWF9KoCZur0HSGU7hk8PdBFKKbYe6+gqdXWz84Jg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1829,15 +1844,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.6.tgz",
-			"integrity": "sha512-6cBG5mBvUu4VUD04OHKnYzbuHNP8huDsD3EDqqpIpsswTDoqHCjLoHb6+QgsV1WsT2nipRqCPgxD3LXnEO7XfA==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.5.tgz",
+			"integrity": "sha512-E0VWu/hk83BIFUWnsKZ4D81KXjN5L3MobvevOHErASk9IPwKHOkTgvqzvNo1yP/ePJWqqK2SpUR5z+KQbl6NVw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-create-class-features-plugin": "^7.23.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-typescript": "^7.23.3"
+				"@babel/helper-create-class-features-plugin": "^7.24.5",
+				"@babel/helper-plugin-utils": "^7.24.5",
+				"@babel/plugin-syntax-typescript": "^7.24.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1847,12 +1862,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.23.3.tgz",
-			"integrity": "sha512-OMCUx/bU6ChE3r4+ZdylEqAjaQgHAgipgW8nsCfu5pGqDcFytVd91AwRvUJSBZDz0exPGgnjoqhgRYLRjFZc9Q==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.1.tgz",
+			"integrity": "sha512-RlkVIcWT4TLI96zM660S877E7beKlQw7Ig+wqkKBiWfj0zH5Q4h50q6er4wzZKRNSYpfo6ILJ+hrJAGSX2qcNw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1862,13 +1877,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.23.3.tgz",
-			"integrity": "sha512-KcLIm+pDZkWZQAFJ9pdfmh89EwVfmNovFBcXko8szpBeF8z68kWIPeKlmSOkT9BXJxs2C0uk+5LxoxIv62MROA==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.1.tgz",
+			"integrity": "sha512-Ss4VvlfYV5huWApFsF8/Sq0oXnGO+jB+rijFEFugTd3cwSObUSnUi88djgR5528Csl0uKlrI331kRqe56Ov2Ng==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1878,13 +1893,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.23.3.tgz",
-			"integrity": "sha512-wMHpNA4x2cIA32b/ci3AfwNgheiva2W0WUKWTK7vBHBhDKfPsc5cFGNWm69WBqpwd86u1qwZ9PWevKqm1A3yAw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.1.tgz",
+			"integrity": "sha512-2A/94wgZgxfTsiLaQ2E36XAOdcZmGAaEEgVmxQWwZXWkGhvoHbaqXcKnU8zny4ycpu3vNqg0L/PcCiYtHtA13g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1894,13 +1909,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.23.3.tgz",
-			"integrity": "sha512-W7lliA/v9bNR83Qc3q1ip9CQMZ09CcHDbHfbLRDNuAhn1Mvkr1ZNF7hPmztMQvtTGVLJ9m8IZqWsTkXOml8dbw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.1.tgz",
+			"integrity": "sha512-fqj4WuzzS+ukpgerpAoOnMfQXwUHFxXUZUE84oL2Kao2N8uSlvcpnAidKASgsNgzZHBsHWvcm8s9FPWUhAb8fA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1910,26 +1925,27 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
-			"integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.5.tgz",
+			"integrity": "sha512-UGK2ifKtcC8i5AI4cH+sbLLuLc2ktYSFJgBAXorKAsHUZmrQ1q6aQ6i3BvU24wWs2AAKqQB6kq3N9V9Gw1HiMQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.23.5",
+				"@babel/compat-data": "^7.24.4",
 				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.24.5",
 				"@babel/helper-validator-option": "^7.23.5",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.7",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.5",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.1",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-				"@babel/plugin-syntax-import-assertions": "^7.23.3",
-				"@babel/plugin-syntax-import-attributes": "^7.23.3",
+				"@babel/plugin-syntax-import-assertions": "^7.24.1",
+				"@babel/plugin-syntax-import-attributes": "^7.24.1",
 				"@babel/plugin-syntax-import-meta": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
@@ -1941,58 +1957,58 @@
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-				"@babel/plugin-transform-arrow-functions": "^7.23.3",
-				"@babel/plugin-transform-async-generator-functions": "^7.23.9",
-				"@babel/plugin-transform-async-to-generator": "^7.23.3",
-				"@babel/plugin-transform-block-scoped-functions": "^7.23.3",
-				"@babel/plugin-transform-block-scoping": "^7.23.4",
-				"@babel/plugin-transform-class-properties": "^7.23.3",
-				"@babel/plugin-transform-class-static-block": "^7.23.4",
-				"@babel/plugin-transform-classes": "^7.23.8",
-				"@babel/plugin-transform-computed-properties": "^7.23.3",
-				"@babel/plugin-transform-destructuring": "^7.23.3",
-				"@babel/plugin-transform-dotall-regex": "^7.23.3",
-				"@babel/plugin-transform-duplicate-keys": "^7.23.3",
-				"@babel/plugin-transform-dynamic-import": "^7.23.4",
-				"@babel/plugin-transform-exponentiation-operator": "^7.23.3",
-				"@babel/plugin-transform-export-namespace-from": "^7.23.4",
-				"@babel/plugin-transform-for-of": "^7.23.6",
-				"@babel/plugin-transform-function-name": "^7.23.3",
-				"@babel/plugin-transform-json-strings": "^7.23.4",
-				"@babel/plugin-transform-literals": "^7.23.3",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.23.4",
-				"@babel/plugin-transform-member-expression-literals": "^7.23.3",
-				"@babel/plugin-transform-modules-amd": "^7.23.3",
-				"@babel/plugin-transform-modules-commonjs": "^7.23.3",
-				"@babel/plugin-transform-modules-systemjs": "^7.23.9",
-				"@babel/plugin-transform-modules-umd": "^7.23.3",
+				"@babel/plugin-transform-arrow-functions": "^7.24.1",
+				"@babel/plugin-transform-async-generator-functions": "^7.24.3",
+				"@babel/plugin-transform-async-to-generator": "^7.24.1",
+				"@babel/plugin-transform-block-scoped-functions": "^7.24.1",
+				"@babel/plugin-transform-block-scoping": "^7.24.5",
+				"@babel/plugin-transform-class-properties": "^7.24.1",
+				"@babel/plugin-transform-class-static-block": "^7.24.4",
+				"@babel/plugin-transform-classes": "^7.24.5",
+				"@babel/plugin-transform-computed-properties": "^7.24.1",
+				"@babel/plugin-transform-destructuring": "^7.24.5",
+				"@babel/plugin-transform-dotall-regex": "^7.24.1",
+				"@babel/plugin-transform-duplicate-keys": "^7.24.1",
+				"@babel/plugin-transform-dynamic-import": "^7.24.1",
+				"@babel/plugin-transform-exponentiation-operator": "^7.24.1",
+				"@babel/plugin-transform-export-namespace-from": "^7.24.1",
+				"@babel/plugin-transform-for-of": "^7.24.1",
+				"@babel/plugin-transform-function-name": "^7.24.1",
+				"@babel/plugin-transform-json-strings": "^7.24.1",
+				"@babel/plugin-transform-literals": "^7.24.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.24.1",
+				"@babel/plugin-transform-member-expression-literals": "^7.24.1",
+				"@babel/plugin-transform-modules-amd": "^7.24.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.24.1",
+				"@babel/plugin-transform-modules-systemjs": "^7.24.1",
+				"@babel/plugin-transform-modules-umd": "^7.24.1",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
-				"@babel/plugin-transform-new-target": "^7.23.3",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
-				"@babel/plugin-transform-numeric-separator": "^7.23.4",
-				"@babel/plugin-transform-object-rest-spread": "^7.23.4",
-				"@babel/plugin-transform-object-super": "^7.23.3",
-				"@babel/plugin-transform-optional-catch-binding": "^7.23.4",
-				"@babel/plugin-transform-optional-chaining": "^7.23.4",
-				"@babel/plugin-transform-parameters": "^7.23.3",
-				"@babel/plugin-transform-private-methods": "^7.23.3",
-				"@babel/plugin-transform-private-property-in-object": "^7.23.4",
-				"@babel/plugin-transform-property-literals": "^7.23.3",
-				"@babel/plugin-transform-regenerator": "^7.23.3",
-				"@babel/plugin-transform-reserved-words": "^7.23.3",
-				"@babel/plugin-transform-shorthand-properties": "^7.23.3",
-				"@babel/plugin-transform-spread": "^7.23.3",
-				"@babel/plugin-transform-sticky-regex": "^7.23.3",
-				"@babel/plugin-transform-template-literals": "^7.23.3",
-				"@babel/plugin-transform-typeof-symbol": "^7.23.3",
-				"@babel/plugin-transform-unicode-escapes": "^7.23.3",
-				"@babel/plugin-transform-unicode-property-regex": "^7.23.3",
-				"@babel/plugin-transform-unicode-regex": "^7.23.3",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
+				"@babel/plugin-transform-new-target": "^7.24.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.24.1",
+				"@babel/plugin-transform-numeric-separator": "^7.24.1",
+				"@babel/plugin-transform-object-rest-spread": "^7.24.5",
+				"@babel/plugin-transform-object-super": "^7.24.1",
+				"@babel/plugin-transform-optional-catch-binding": "^7.24.1",
+				"@babel/plugin-transform-optional-chaining": "^7.24.5",
+				"@babel/plugin-transform-parameters": "^7.24.5",
+				"@babel/plugin-transform-private-methods": "^7.24.1",
+				"@babel/plugin-transform-private-property-in-object": "^7.24.5",
+				"@babel/plugin-transform-property-literals": "^7.24.1",
+				"@babel/plugin-transform-regenerator": "^7.24.1",
+				"@babel/plugin-transform-reserved-words": "^7.24.1",
+				"@babel/plugin-transform-shorthand-properties": "^7.24.1",
+				"@babel/plugin-transform-spread": "^7.24.1",
+				"@babel/plugin-transform-sticky-regex": "^7.24.1",
+				"@babel/plugin-transform-template-literals": "^7.24.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.24.5",
+				"@babel/plugin-transform-unicode-escapes": "^7.24.1",
+				"@babel/plugin-transform-unicode-property-regex": "^7.24.1",
+				"@babel/plugin-transform-unicode-regex": "^7.24.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.24.1",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.8",
-				"babel-plugin-polyfill-corejs3": "^0.9.0",
-				"babel-plugin-polyfill-regenerator": "^0.5.5",
+				"babel-plugin-polyfill-corejs2": "^0.4.10",
+				"babel-plugin-polyfill-corejs3": "^0.10.4",
+				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
@@ -2018,17 +2034,17 @@
 			}
 		},
 		"node_modules/@babel/preset-react": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.23.3.tgz",
-			"integrity": "sha512-tbkHOS9axH6Ysf2OUEqoSZ6T3Fa2SrNH6WTWSPBboxKzdxNc9qOICeLXkNG0ZEwbQ1HY8liwOce4aN/Ceyuq6w==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.24.1.tgz",
+			"integrity": "sha512-eFa8up2/8cZXLIpkafhaADTXSnl7IsUFCYenRWrARBz0/qZwcT0RBXpys0LJU4+WfPoF2ZG6ew6s2V6izMCwRA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-validator-option": "^7.22.15",
-				"@babel/plugin-transform-react-display-name": "^7.23.3",
-				"@babel/plugin-transform-react-jsx": "^7.22.15",
+				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-validator-option": "^7.23.5",
+				"@babel/plugin-transform-react-display-name": "^7.24.1",
+				"@babel/plugin-transform-react-jsx": "^7.23.4",
 				"@babel/plugin-transform-react-jsx-development": "^7.22.5",
-				"@babel/plugin-transform-react-pure-annotations": "^7.23.3"
+				"@babel/plugin-transform-react-pure-annotations": "^7.24.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2038,16 +2054,16 @@
 			}
 		},
 		"node_modules/@babel/preset-typescript": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.3.tgz",
-			"integrity": "sha512-17oIGVlqz6CchO9RFYn5U6ZpWRZIngayYCtrPRSgANSwC2V1Jb+iP74nVxzzXJte8b8BYxrL1yY96xfhTBrNNQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.1.tgz",
+			"integrity": "sha512-1DBaMmRDpuYQBPWD8Pf/WEwCrtgRHxsZnP4mIy9G/X+hFfbI47Q2G4t1Paakld84+qsk2fSsUPMKg71jkoOOaQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-validator-option": "^7.22.15",
-				"@babel/plugin-syntax-jsx": "^7.23.3",
-				"@babel/plugin-transform-modules-commonjs": "^7.23.3",
-				"@babel/plugin-transform-typescript": "^7.23.3"
+				"@babel/helper-plugin-utils": "^7.24.0",
+				"@babel/helper-validator-option": "^7.23.5",
+				"@babel/plugin-syntax-jsx": "^7.24.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.24.1",
+				"@babel/plugin-transform-typescript": "^7.24.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2109,13 +2125,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.24.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-			"integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+			"integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.23.4",
-				"@babel/helper-validator-identifier": "^7.22.20",
+				"@babel/helper-string-parser": "^7.24.1",
+				"@babel/helper-validator-identifier": "^7.24.5",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -2462,9 +2478,9 @@
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
-			"integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.9.tgz",
+			"integrity": "sha512-q0umO0+LQK4+p6aGyvzASqKbKOJcAHJ7ycE9CuUvfx3s9zTHWmGJTPOIlM/hmSBfUfg/XfY5YhLBLR/LHwShQQ==",
 			"dev": true,
 			"dependencies": {
 				"@floating-ui/dom": "^1.0.0"
@@ -3184,13 +3200,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-			"integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+			"version": "1.43.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
+			"integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.41.2"
+				"playwright": "1.43.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3266,12 +3282,12 @@
 			}
 		},
 		"node_modules/@preact/signals": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.2.tgz",
-			"integrity": "sha512-ColCqdo4cRP18bAuIR4Oik5rDpiyFtPIJIygaYPMEAwTnl4buWkBOflGBSzhYyPyJfKpkwlekrvK+1pzQ2ldWw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.3.tgz",
+			"integrity": "sha512-M2DXse3Wi8HwjI1d2vQWOLJ3lHogvqTsJYvl4ofXRXgMFQzJ7kmlZvlt5i8x5S5VwgZu0ghru4HkLqOoFfU2JQ==",
 			"dev": true,
 			"dependencies": {
-				"@preact/signals-core": "^1.4.0"
+				"@preact/signals-core": "^1.6.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3282,9 +3298,9 @@
 			}
 		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.5.1.tgz",
-			"integrity": "sha512-dE6f+WCX5ZUDwXzUIWNMhhglmuLpqJhuy3X3xHrhZYI0Hm2LyQwOu0l9mdPiWrVNsE+Q7txOnJPgtIqHCYoBVA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.6.0.tgz",
+			"integrity": "sha512-O/XGxwP85h1F7+ouqTMOIZ3+V1whfaV9ToIVcuyGriD4JkSD00cQo54BKdqjvBJxbenvp7ynfqRHEwI6e+NIhw==",
 			"dev": true,
 			"funding": {
 				"type": "opencollective",
@@ -4445,19 +4461,18 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "18.2.58",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.58.tgz",
-			"integrity": "sha512-TaGvMNhxvG2Q0K0aYxiKfNDS5m5ZsoIBBbtfUorxdH4NGSXIlYvZxLJI+9Dd3KjeB3780bciLyAb7ylO8pLhPw==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"@types/scheduler": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "18.2.19",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
-			"integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+			"version": "18.3.0",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
 			"dependencies": {
 				"@types/react": "*"
 			}
@@ -4467,11 +4482,6 @@
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"dev": true
-		},
-		"node_modules/@types/scheduler": {
-			"version": "0.16.8",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.8",
@@ -4545,12 +4555,6 @@
 			"integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
 			"dev": true
 		},
-		"node_modules/@types/tinycolor2": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
-			"integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
-			"dev": true
-		},
 		"node_modules/@types/tough-cookie": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -4610,18 +4614,92 @@
 			}
 		},
 		"node_modules/@types/wordpress__block-editor": {
-			"version": "11.5.10",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.10.tgz",
-			"integrity": "sha512-+cv7XP9ht3QZJFb59Os9cLlq6TNHTLugeaf+bR3mPGnzlCRXbyHN81TxfSXjhpB6Y8oKFcDUpVlrVRmoJ9QJGQ==",
+			"version": "11.5.14",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.14.tgz",
+			"integrity": "sha512-qW1yD9Nrsy6x4cxMYCSXW6v74bXfcstPQeOV+uQbMejd5zxrBGytH9OQvcrIJrDquPzDf5+We8VqnsIWTF/Rpg==",
 			"dev": true,
 			"dependencies": {
 				"@types/react": "*",
 				"@types/wordpress__blocks": "*",
-				"@types/wordpress__components": "*",
-				"@types/wordpress__keycodes": "*",
+				"@wordpress/components": "^27.2.0",
 				"@wordpress/data": "^9.13.0",
 				"@wordpress/element": "^5.0.0",
+				"@wordpress/keycodes": "^3.54.0",
 				"react-autosize-textarea": "^7.1.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/components": {
+			"version": "27.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-27.4.0.tgz",
+			"integrity": "sha512-sYQ1O6E9VLSICu8L5PYXcJkU9Er880FEFkk7HYqB4dQOQ8dbyzsgpVYNd61h0UcTQ740r0TtkZCIK0D+TjMICg==",
+			"dev": true,
+			"dependencies": {
+				"@ariakit/react": "^0.3.12",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.2.24",
+				"@wordpress/a11y": "^3.56.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/date": "^4.56.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/dom": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/escape-html": "^2.56.0",
+				"@wordpress/hooks": "^3.56.0",
+				"@wordpress/html-entities": "^3.56.0",
+				"@wordpress/i18n": "^4.56.0",
+				"@wordpress/icons": "^9.47.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/keycodes": "^3.56.0",
+				"@wordpress/primitives": "^3.54.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/rich-text": "^6.33.0",
+				"@wordpress/warning": "^2.56.0",
+				"change-case": "^4.1.2",
+				"classnames": "^2.3.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"downshift": "^6.0.15",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^10.13.0",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/components/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/data": {
@@ -4653,6 +4731,16 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@types/wordpress__block-editor/node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"node_modules/@types/wordpress__block-editor/node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -4662,17 +4750,110 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@types/wordpress__block-editor/node_modules/path-to-regexp": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+			"dev": true
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/@types/wordpress__blocks": {
-			"version": "12.5.13",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-12.5.13.tgz",
-			"integrity": "sha512-k2nlqxdNyaL6Uf/+zWhXeJJMKaPpikh5GdunNhNtpI1nSHM18Y+86y3rzjt1n0WcUQc1XkosvhcAEiGNYIhL9g==",
+			"version": "12.5.14",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-12.5.14.tgz",
+			"integrity": "sha512-eXEnCRKYu+39KEJ/OYpoYxWTATxI+eJHd+meMGZ14hYydFtxA0Y8M7zJT8D8f4klBo8wINLvP7zrO8vYrjWjPQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/react": "*",
-				"@types/wordpress__components": "*",
 				"@types/wordpress__shortcode": "*",
+				"@wordpress/components": "^27.2.0",
 				"@wordpress/data": "^9.13.0",
 				"@wordpress/element": "^5.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/components": {
+			"version": "27.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-27.4.0.tgz",
+			"integrity": "sha512-sYQ1O6E9VLSICu8L5PYXcJkU9Er880FEFkk7HYqB4dQOQ8dbyzsgpVYNd61h0UcTQ740r0TtkZCIK0D+TjMICg==",
+			"dev": true,
+			"dependencies": {
+				"@ariakit/react": "^0.3.12",
+				"@babel/runtime": "^7.16.0",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.2.24",
+				"@wordpress/a11y": "^3.56.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/date": "^4.56.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/dom": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/escape-html": "^2.56.0",
+				"@wordpress/hooks": "^3.56.0",
+				"@wordpress/html-entities": "^3.56.0",
+				"@wordpress/i18n": "^4.56.0",
+				"@wordpress/icons": "^9.47.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/keycodes": "^3.56.0",
+				"@wordpress/primitives": "^3.54.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/rich-text": "^6.33.0",
+				"@wordpress/warning": "^2.56.0",
+				"change-case": "^4.1.2",
+				"classnames": "^2.3.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"downshift": "^6.0.15",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^10.13.0",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"use-lilius": "^2.0.5",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/components/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@types/wordpress__blocks/node_modules/@wordpress/data": {
@@ -4704,6 +4885,16 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@types/wordpress__blocks/node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"node_modules/@types/wordpress__blocks/node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -4713,121 +4904,23 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@types/wordpress__components": {
-			"version": "23.0.11",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__components/-/wordpress__components-23.0.11.tgz",
-			"integrity": "sha512-Y6m+HC3/1UeIQJYhKprEmHbo4bxhuvH60Oeb0VEnQ6AimdPWEYpDv9J9XTMJ5VqIJ0rrM8h0jfkmBOFRABNZgA==",
-			"dev": true,
-			"dependencies": {
-				"@types/react": "*",
-				"@types/tinycolor2": "*",
-				"@types/wordpress__notices": "*",
-				"@types/wordpress__rich-text": "*",
-				"@wordpress/element": "^5.0.0",
-				"downshift": "^6.0.15",
-				"re-resizable": "^6.4.0"
-			}
-		},
-		"node_modules/@types/wordpress__keycodes": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__keycodes/-/wordpress__keycodes-2.3.3.tgz",
-			"integrity": "sha512-jOI0L5NbLc0Ht/vkbZwgBfgWZbPKexXS+nxlYZ0kHQCjVCM7tdSwptItksCY3Qc9IV2nRc1pTnj/UJC2E2cUQw==",
+		"node_modules/@types/wordpress__blocks/node_modules/path-to-regexp": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
 			"dev": true
 		},
-		"node_modules/@types/wordpress__notices": {
-			"version": "3.27.6",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__notices/-/wordpress__notices-3.27.6.tgz",
-			"integrity": "sha512-cKK9Cu/br81XqNwxUTRjwGZuLtf6Ug76O77Qc1YF4+RhY8pruxKcWa2+TYzojeh6/83HXw4JjXY7tiI/WD4uoA==",
+		"node_modules/@types/wordpress__blocks/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
 			"dev": true,
-			"dependencies": {
-				"@types/react": "*",
-				"@wordpress/data": "^9.13.0"
-			}
-		},
-		"node_modules/@types/wordpress__notices/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
-				"deepmerge": "^4.3.0",
-				"equivalent-key-map": "^0.2.2",
-				"is-plain-object": "^5.0.0",
-				"is-promise": "^4.0.0",
-				"redux": "^4.1.2",
-				"rememo": "^4.0.2",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@types/wordpress__notices/node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@types/wordpress__rich-text": {
-			"version": "6.4.5",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__rich-text/-/wordpress__rich-text-6.4.5.tgz",
-			"integrity": "sha512-t+3EvAxkByO6/naRM5FKr1s33d72L/qHLXXdmHiPm54xUxIW6azQFhUWfScRlCcFTlszdwgJyqpaw4HJQIiZ8g==",
-			"dev": true,
-			"dependencies": {
-				"@types/react": "*",
-				"@wordpress/data": "^9.13.0"
-			}
-		},
-		"node_modules/@types/wordpress__rich-text/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
-				"deepmerge": "^4.3.0",
-				"equivalent-key-map": "^0.2.2",
-				"is-plain-object": "^5.0.0",
-				"is-promise": "^4.0.0",
-				"redux": "^4.1.2",
-				"rememo": "^4.0.2",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@types/wordpress__rich-text/node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@types/wordpress__shortcode": {
@@ -4871,33 +4964,34 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+			"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/type-utils": "6.21.0",
-				"@typescript-eslint/utils": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/type-utils": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.4",
-				"natural-compare": "^1.4.0",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"ignore": "^5.2.0",
+				"natural-compare-lite": "^1.4.0",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-				"eslint": "^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -4910,6 +5004,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -4922,6 +5018,8 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
 			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -4936,29 +5034,32 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -4967,16 +5068,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0"
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4984,25 +5085,27 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-			"integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+			"integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"@typescript-eslint/utils": "6.21.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
 				"debug": "^4.3.4",
-				"ts-api-utils": "^1.0.1"
+				"tsutils": "^3.21.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "*"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -5011,12 +5114,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
 			"dev": true,
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5024,22 +5127,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5058,15 +5160,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
@@ -5101,21 +5194,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -5138,28 +5216,51 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"semver": "^7.5.4"
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@types/json-schema": "^7.0.9",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"eslint-scope": "^5.1.1",
+				"semver": "^7.3.7"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
@@ -5196,16 +5297,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"eslint-visitor-keys": "^3.4.1"
+				"@typescript-eslint/types": "5.62.0",
+				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5427,37 +5528,37 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.52.0.tgz",
-			"integrity": "sha512-s+Rhh+jjVFfoJqlz4483zOT5+d/qr5lMxlQaEsPCd1dxI5TZBon8nQQ16rCe+b21RwJJQ1hz4v3Mavoff6fr0A==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.56.0.tgz",
+			"integrity": "sha512-Q3xWPlAhCrwPidqpfVfOXpEMUZEb89xY9jzg+h4MTEwGcA6M24stSuxdDyeUVA1VG75juC41n+Vzb/Zbf8Lgzw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/dom-ready": "^3.52.0",
-				"@wordpress/i18n": "^4.52.0"
+				"@wordpress/dom-ready": "^3.56.0",
+				"@wordpress/i18n": "^4.56.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "6.49.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.49.0.tgz",
-			"integrity": "sha512-bU42wZuZKH6nPz6diHflznXVond9nKzWwn0xOR4KWXd0NRKvDhNobU0lyjLF/JmwNqE8PZF65a8M9agpfROgqQ==",
+			"version": "6.53.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.53.0.tgz",
+			"integrity": "sha512-jHYueGfGfe89akyw1A28WGl17qIKTukMTwol4rHkZY43ygUmSJiTF/FSsExzMwk/j7OmGGr+GTa1TPO/tc71Lw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.52.0",
-				"@wordpress/url": "^3.53.0"
+				"@wordpress/i18n": "^4.56.0",
+				"@wordpress/url": "^3.57.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/autop": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.52.0.tgz",
-			"integrity": "sha512-2qRlenhMzaUsDCzIS5unNsWOUNugSm5VG9rDCjOZgEdm7WngEIHfc2ANbS+bodtntr3MBa5cQnLKT19ri+vVkg==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.56.0.tgz",
+			"integrity": "sha512-825x87DrX1z3uJoKUqFpQ76OIeyrTc8t3c/MIy4/zBV+5lEEAvFi5fn5y8Xd9Wwjn1Zhq6b1wzmcWXvNIlq5Fg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -5467,9 +5568,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-			"version": "4.36.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.36.0.tgz",
-			"integrity": "sha512-xgBy9HnA0xL5e0Ipku7Ga3QimrfwTQ3njnN79mT8wNcim2APIlyiWSG3GndTdPoSGdrxGPv2ZrpqBdKsiGzoWQ==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.39.0.tgz",
+			"integrity": "sha512-yQySutPQq+Joa3ePzc9X8f5hZacmcn5e9KMiJYrXBUqj5VKl4RR8N3e+UOl1lWoB2NI/7bA9tW9TXJlDpHJX1w==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -5479,9 +5580,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "7.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.37.0.tgz",
-			"integrity": "sha512-XE9NUIoc428MHP3p6DMNjRV4Df97K9JHkzXwOwJjjHp00ce2ckh4wSkZh287Zi1X+uNcrROERtSp4jjWHUhvHA==",
+			"version": "7.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.40.0.tgz",
+			"integrity": "sha512-/guM3C4NMoLK0pNO5Epbm/50L/MqXB0k3+fLtPbw3BC3v8Aus7ktE2l85gilowNyE3kYAyjFR/BsG5tassnaVQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
@@ -5490,9 +5591,9 @@
 				"@babel/preset-env": "^7.16.0",
 				"@babel/preset-typescript": "^7.16.0",
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^4.36.0",
-				"@wordpress/browserslist-config": "^5.36.0",
-				"@wordpress/warning": "^2.53.0",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^4.39.0",
+				"@wordpress/browserslist-config": "^5.39.0",
+				"@wordpress/warning": "^2.56.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.2.0"
@@ -5502,15 +5603,15 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "4.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.43.0.tgz",
-			"integrity": "sha512-jo4q47f0Yf52XJuVfW2VGN6D5KTLfU1O3dhM/j4xP4sb9fH/L7SugzXJ0UmtzOJW0X8Rp14eZWy+GNVcPCHofA==",
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.47.0.tgz",
+			"integrity": "sha512-1myPBFLuMnuxUE8M2VGZ+wbGhgasLNqFdxQnWfYDMRhaSESsZgaLaMoasNZ4+e/N7Nssl97ad/XGwZ721HXqvQ==",
 			"dev": true
 		},
 		"node_modules/@wordpress/blob": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.52.0.tgz",
-			"integrity": "sha512-a3bRqtQZ0ctLCOrorzywnlkxBH5sQ1p0o3LfxLA6aBGrF4DHYBnKFtS1GuT+rck26yjkaOncLd+1PF6h2knD9g==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.56.0.tgz",
+			"integrity": "sha512-tAFmFhNh0OgAUTIoeaAyfB92uA9os7vDK2xBQv66q84tBdW45Vq5wXKUQ+F/IfcN2jUzGPO6GX5GVyADXmTYtQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -5520,45 +5621,47 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor": {
-			"version": "11.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-11.8.0.tgz",
-			"integrity": "sha512-rSiDZaIXR9iMAdtRR78ZEYrIxgHop1IrGIUNOwacEc5pDYXFHxGveSZp5MhRlL8n9wkV5UdwZUD8gMAHwYpuyw==",
+			"version": "12.3.15",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.3.15.tgz",
+			"integrity": "sha512-eFzfQhGlE3rgtFLtdOo5VaKY1dOpm1WEjaL5IYo490fevSJ/NN3rHJqT8t6ami+vS6LnbH3DEviXwkDxKd8Wgw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
+				"@emotion/styled": "^11.6.0",
 				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^3.31.0",
-				"@wordpress/api-fetch": "^6.28.0",
-				"@wordpress/blob": "^3.31.0",
-				"@wordpress/blocks": "^12.8.0",
-				"@wordpress/components": "^23.8.0",
-				"@wordpress/compose": "^6.8.0",
-				"@wordpress/data": "^9.1.0",
-				"@wordpress/date": "^4.31.0",
-				"@wordpress/deprecated": "^3.31.0",
-				"@wordpress/dom": "^3.31.0",
-				"@wordpress/element": "^5.8.0",
-				"@wordpress/escape-html": "^2.31.0",
-				"@wordpress/hooks": "^3.31.0",
-				"@wordpress/html-entities": "^3.31.0",
-				"@wordpress/i18n": "^4.31.0",
-				"@wordpress/icons": "^9.22.0",
-				"@wordpress/is-shallow-equal": "^4.31.0",
-				"@wordpress/keyboard-shortcuts": "^4.8.0",
-				"@wordpress/keycodes": "^3.31.0",
-				"@wordpress/notices": "^3.31.0",
-				"@wordpress/preferences": "^3.8.0",
-				"@wordpress/private-apis": "^0.13.0",
-				"@wordpress/rich-text": "^6.8.0",
-				"@wordpress/shortcode": "^3.31.0",
-				"@wordpress/style-engine": "^1.14.0",
-				"@wordpress/token-list": "^2.31.0",
-				"@wordpress/url": "^3.32.0",
-				"@wordpress/warning": "^2.31.0",
-				"@wordpress/wordcount": "^3.31.0",
+				"@wordpress/a11y": "^3.35.2",
+				"@wordpress/api-fetch": "^6.32.2",
+				"@wordpress/blob": "^3.35.2",
+				"@wordpress/blocks": "^12.12.8",
+				"@wordpress/components": "^25.1.12",
+				"@wordpress/compose": "^6.12.3",
+				"@wordpress/data": "^9.5.6",
+				"@wordpress/date": "^4.35.2",
+				"@wordpress/deprecated": "^3.35.2",
+				"@wordpress/dom": "^3.35.2",
+				"@wordpress/element": "^5.12.2",
+				"@wordpress/escape-html": "^2.35.2",
+				"@wordpress/hooks": "^3.35.2",
+				"@wordpress/html-entities": "^3.35.2",
+				"@wordpress/i18n": "^4.35.2",
+				"@wordpress/icons": "^9.26.3",
+				"@wordpress/is-shallow-equal": "^4.35.2",
+				"@wordpress/keyboard-shortcuts": "^4.12.6",
+				"@wordpress/keycodes": "^3.35.2",
+				"@wordpress/notices": "^4.3.6",
+				"@wordpress/preferences": "^3.12.12",
+				"@wordpress/private-apis": "^0.17.3",
+				"@wordpress/rich-text": "^6.12.9",
+				"@wordpress/shortcode": "^3.35.2",
+				"@wordpress/style-engine": "^1.18.2",
+				"@wordpress/token-list": "^2.35.2",
+				"@wordpress/url": "^3.36.2",
+				"@wordpress/warning": "^2.35.2",
+				"@wordpress/wordcount": "^3.35.2",
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
+				"deepmerge": "^4.3.0",
 				"diff": "^4.0.2",
 				"dom-scroll-into-view": "^1.2.1",
 				"fast-deep-equal": "^3.1.3",
@@ -5566,7 +5669,7 @@
 				"lodash": "^4.17.21",
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^4.5.1",
-				"rememo": "^4.0.0",
+				"rememo": "^4.0.2",
 				"remove-accents": "^0.4.2",
 				"traverse": "^0.6.6"
 			},
@@ -5620,9 +5723,9 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/private-apis": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.13.0.tgz",
-			"integrity": "sha512-tGbWnwcDCwmSZcr1EegjOUrm3aXveIrZOEbKbpSOXXa+XfyXsFhfgRJV+NW8taSfV3eltLXp/6S8tBJHMBTh0A==",
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.17.3.tgz",
+			"integrity": "sha512-D2qjamJf1OwIIjJHShk+lC+nU9pCRd70+x8qx6ZIbbU7xXT/bl+9IvWseMLoT12QW3ReQNcvzNMP7Uds+tcphw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -5647,53 +5750,55 @@
 			"dev": true
 		},
 		"node_modules/@wordpress/block-library": {
-			"version": "8.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-8.29.0.tgz",
-			"integrity": "sha512-TXu3hqaaaj70ABgfT/otJpBGE2L2aF6RSzp684WcygfMlJgbgbpx4ZVOtfX39XH9Lwi6QEpLu588cX3EY7/7yA==",
+			"version": "8.12.19",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-8.12.19.tgz",
+			"integrity": "sha512-GPbIkap9LS7B47pGVO9DlVyb49uyUtDik9a2mrji3ht3CPPtNFHrzMu5cCCS9OtxeLI0U6agFNs5lHjzdRLfpw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^3.52.0",
-				"@wordpress/api-fetch": "^6.49.0",
-				"@wordpress/autop": "^3.52.0",
-				"@wordpress/blob": "^3.52.0",
-				"@wordpress/block-editor": "^12.20.0",
-				"@wordpress/blocks": "^12.29.0",
-				"@wordpress/components": "^27.0.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/core-data": "^6.29.0",
-				"@wordpress/data": "^9.22.0",
-				"@wordpress/date": "^4.52.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/dom": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/escape-html": "^2.52.0",
-				"@wordpress/hooks": "^3.52.0",
-				"@wordpress/html-entities": "^3.52.0",
-				"@wordpress/i18n": "^4.52.0",
-				"@wordpress/icons": "^9.43.0",
-				"@wordpress/interactivity": "^5.1.0",
-				"@wordpress/interactivity-router": "^1.2.0",
-				"@wordpress/keycodes": "^3.52.0",
-				"@wordpress/notices": "^4.20.0",
-				"@wordpress/patterns": "^1.13.0",
-				"@wordpress/primitives": "^3.50.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/reusable-blocks": "^4.29.0",
-				"@wordpress/rich-text": "^6.29.0",
-				"@wordpress/server-side-render": "^4.29.0",
-				"@wordpress/url": "^3.53.0",
-				"@wordpress/viewport": "^5.29.0",
-				"@wordpress/wordcount": "^3.52.0",
+				"@preact/signals": "^1.1.3",
+				"@wordpress/a11y": "^3.35.2",
+				"@wordpress/api-fetch": "^6.32.2",
+				"@wordpress/autop": "^3.35.2",
+				"@wordpress/blob": "^3.35.2",
+				"@wordpress/block-editor": "^12.3.15",
+				"@wordpress/blocks": "^12.12.8",
+				"@wordpress/components": "^25.1.12",
+				"@wordpress/compose": "^6.12.3",
+				"@wordpress/core-data": "^6.12.16",
+				"@wordpress/data": "^9.5.6",
+				"@wordpress/date": "^4.35.2",
+				"@wordpress/deprecated": "^3.35.2",
+				"@wordpress/dom": "^3.35.2",
+				"@wordpress/element": "^5.12.2",
+				"@wordpress/escape-html": "^2.35.2",
+				"@wordpress/hooks": "^3.35.2",
+				"@wordpress/html-entities": "^3.35.2",
+				"@wordpress/i18n": "^4.35.2",
+				"@wordpress/icons": "^9.26.3",
+				"@wordpress/keycodes": "^3.35.2",
+				"@wordpress/notices": "^4.3.6",
+				"@wordpress/primitives": "^3.33.2",
+				"@wordpress/private-apis": "^0.17.3",
+				"@wordpress/reusable-blocks": "^4.12.16",
+				"@wordpress/rich-text": "^6.12.9",
+				"@wordpress/server-side-render": "^4.12.14",
+				"@wordpress/url": "^3.36.2",
+				"@wordpress/viewport": "^5.12.6",
+				"@wordpress/wordcount": "^3.35.2",
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
+				"deepsignal": "^1.3.0",
 				"escape-html": "^1.0.3",
 				"fast-average-color": "^9.1.1",
 				"fast-deep-equal": "^3.1.3",
+				"lodash": "^4.17.21",
 				"memize": "^2.1.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"micromodal": "^0.4.10",
+				"preact": "^10.13.2",
+				"remove-accents": "^0.4.2",
+				"uuid": "^8.3.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -5701,19 +5806,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/block-library/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-			"dev": true,
-			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/block-editor": {
@@ -5778,6 +5870,83 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/block-editor/node_modules/@wordpress/private-apis": {
+			"version": "0.34.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.34.0.tgz",
+			"integrity": "sha512-2CdKDjEHCSXCwIyxci6pHfKkXQbKrrXo+K5kILz3YX7ie/5MGOCtCC+/e0tExDe+N7HbTn5qso0GIcUw5kWYZQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/block-editor/node_modules/remove-accents": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+			"dev": true
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/blocks": {
+			"version": "12.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.33.0.tgz",
+			"integrity": "sha512-XXxwoVsI6C55YU7RrVYcm//cxIwUNZN+jF9bKR9hA0f4q9W2g/TA3Tbgakj6aHrnQ8/6UGj0Ib+0XmQygK5Qdg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/autop": "^3.56.0",
+				"@wordpress/blob": "^3.56.0",
+				"@wordpress/block-serialization-default-parser": "^4.56.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/data": "^9.26.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/dom": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/hooks": "^3.56.0",
+				"@wordpress/html-entities": "^3.56.0",
+				"@wordpress/i18n": "^4.56.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/rich-text": "^6.33.0",
+				"@wordpress/shortcode": "^3.56.0",
+				"change-case": "^4.1.2",
+				"colord": "^2.7.0",
+				"fast-deep-equal": "^3.1.3",
+				"hpq": "^1.3.0",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"react-is": "^18.2.0",
+				"remove-accents": "^0.5.0",
+				"showdown": "^1.9.1",
+				"simple-html-tokenizer": "^0.5.7",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/blocks/node_modules/remove-accents": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+			"dev": true
+		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/components": {
 			"version": "27.0.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-27.0.0.tgz",
@@ -5841,20 +6010,38 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/components/node_modules/@wordpress/private-apis": {
+			"version": "0.34.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.34.0.tgz",
+			"integrity": "sha512-2CdKDjEHCSXCwIyxci6pHfKkXQbKrrXo+K5kILz3YX7ie/5MGOCtCC+/e0tExDe+N7HbTn5qso0GIcUw5kWYZQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/components/node_modules/remove-accents": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+			"dev": true
+		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
+			"version": "9.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.26.0.tgz",
+			"integrity": "sha512-4zL38nhuSvNUGivYqZ3mj9WSWc40szQT7RaRC/Ih+8B7JN5MPGnJMtZ95eTNqqmD1Os9XEMpeG/oOUY+Pt4+/A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/priority-queue": "^2.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/redux-routine": "^4.56.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -5868,6 +6055,18 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/notices": {
@@ -5887,6 +6086,18 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/block-library/node_modules/@wordpress/private-apis": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.17.3.tgz",
+			"integrity": "sha512-D2qjamJf1OwIIjJHShk+lC+nU9pCRd70+x8qx6ZIbbU7xXT/bl+9IvWseMLoT12QW3ReQNcvzNMP7Uds+tcphw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@wordpress/block-library/node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -5900,6 +6111,12 @@
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
 			"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+			"dev": true
+		},
+		"node_modules/@wordpress/block-library/node_modules/remove-accents": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+			"integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
 			"dev": true
 		},
 		"node_modules/@wordpress/block-library/node_modules/uuid": {
@@ -5916,9 +6133,9 @@
 			}
 		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
-			"version": "4.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.52.0.tgz",
-			"integrity": "sha512-MBpAKv8iuUC+S8RDhPig220uO2qFaNsQvQU7Kr6/MsLUUOf6l3zy8TVLTCFuE66enCIZuLsVAsKeEOr5ZXQ3lw==",
+			"version": "4.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.56.0.tgz",
+			"integrity": "sha512-exGj75HXXhZiAlUT8FRWatBSfVpkZKRXc59sb96hkAhA/QoiLC9S8O//a9lZ6oKy6rRCtS8jYSHFLe7P8ZfHPA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -5928,39 +6145,38 @@
 			}
 		},
 		"node_modules/@wordpress/blocks": {
-			"version": "12.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.29.0.tgz",
-			"integrity": "sha512-4rGItMnOeKu+XJswEasXIRvDnCWQZzGT2/L07rjcZ2seiO5o/KINOtl6fdAusDeP8PDps8XqYuUC86sf9HxxyA==",
+			"version": "12.12.8",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.12.8.tgz",
+			"integrity": "sha512-YwBRYXAapr8bjjwl4SKWe2BA5EkL6wbT1hJcjXnp4NUTF+xk6BjGf6U/k6b+K39Y2nPnCZ4JyVWJrihYqBQMxQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/autop": "^3.52.0",
-				"@wordpress/blob": "^3.52.0",
-				"@wordpress/block-serialization-default-parser": "^4.52.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/data": "^9.22.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/dom": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/hooks": "^3.52.0",
-				"@wordpress/html-entities": "^3.52.0",
-				"@wordpress/i18n": "^4.52.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/rich-text": "^6.29.0",
-				"@wordpress/shortcode": "^3.52.0",
+				"@wordpress/autop": "^3.35.2",
+				"@wordpress/blob": "^3.35.2",
+				"@wordpress/block-serialization-default-parser": "^4.35.2",
+				"@wordpress/compose": "^6.12.3",
+				"@wordpress/data": "^9.5.6",
+				"@wordpress/deprecated": "^3.35.2",
+				"@wordpress/dom": "^3.35.2",
+				"@wordpress/element": "^5.12.2",
+				"@wordpress/hooks": "^3.35.2",
+				"@wordpress/html-entities": "^3.35.2",
+				"@wordpress/i18n": "^4.35.2",
+				"@wordpress/is-shallow-equal": "^4.35.2",
+				"@wordpress/private-apis": "^0.17.3",
+				"@wordpress/shortcode": "^3.35.2",
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
+				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
-				"react-is": "^18.2.0",
 				"rememo": "^4.0.2",
-				"remove-accents": "^0.5.0",
+				"remove-accents": "^0.4.2",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
-				"uuid": "^9.0.1"
+				"uuid": "^8.3.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -5998,6 +6214,30 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/blocks/node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
+			"version": "0.34.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.34.0.tgz",
+			"integrity": "sha512-2CdKDjEHCSXCwIyxci6pHfKkXQbKrrXo+K5kILz3YX7ie/5MGOCtCC+/e0tExDe+N7HbTn5qso0GIcUw5kWYZQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.17.3.tgz",
+			"integrity": "sha512-D2qjamJf1OwIIjJHShk+lC+nU9pCRd70+x8qx6ZIbbU7xXT/bl+9IvWseMLoT12QW3ReQNcvzNMP7Uds+tcphw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@wordpress/blocks/node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -6007,23 +6247,16 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@wordpress/blocks/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
+		"node_modules/@wordpress/blocks/node_modules/remove-accents": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+			"integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "5.36.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.36.0.tgz",
-			"integrity": "sha512-D4Y+MhZHAW4mDNFxHGacVpZgOmkkL9k5+TuVchC8cVSdpAt0VSkzKsXAumoQuEYUXyio/NMkhnU153FO+ci3cQ==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.39.0.tgz",
+			"integrity": "sha512-oy5CRWS3WsaFN/KAgOUIE6mmyuFu5qmKZZhQ+voCN+ifXTsj1J6ypR3RyY03Cbojy6kidyVYl3qRyMxbbUwWSQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -6053,19 +6286,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/commands/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-			"dev": true,
-			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/components": {
@@ -6189,11 +6409,12 @@
 			}
 		},
 		"node_modules/@wordpress/components": {
-			"version": "23.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-23.9.0.tgz",
-			"integrity": "sha512-hEgzWe6PSWlUXPRcYX8YyQhL5Wp6TRqmzv+jIDJnYKXZH1UvsK/WcfCtdIOx7Q7oaPKDtH3vdv+0twcrHeN/bA==",
+			"version": "25.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-25.16.0.tgz",
+			"integrity": "sha512-voQuMsO5JbH+JW33TnWurwwvpSb8IQ4XU5wyVMubX4TUwadt+/2ToNJbZIDXoaJPei7vbM81Ft+pH+zGlN8CyA==",
 			"dev": true,
 			"dependencies": {
+				"@ariakit/react": "^0.3.12",
 				"@babel/runtime": "^7.16.0",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
@@ -6201,25 +6422,27 @@
 				"@emotion/serialize": "^1.0.2",
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "1.0.0",
+				"@floating-ui/react-dom": "^2.0.1",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.2.24",
-				"@wordpress/a11y": "^3.32.0",
-				"@wordpress/compose": "^6.9.0",
-				"@wordpress/date": "^4.32.0",
-				"@wordpress/deprecated": "^3.32.0",
-				"@wordpress/dom": "^3.32.0",
-				"@wordpress/element": "^5.9.0",
-				"@wordpress/escape-html": "^2.32.0",
-				"@wordpress/hooks": "^3.32.0",
-				"@wordpress/html-entities": "^3.32.0",
-				"@wordpress/i18n": "^4.32.0",
-				"@wordpress/icons": "^9.23.0",
-				"@wordpress/is-shallow-equal": "^4.32.0",
-				"@wordpress/keycodes": "^3.32.0",
-				"@wordpress/primitives": "^3.30.0",
-				"@wordpress/private-apis": "^0.14.0",
-				"@wordpress/rich-text": "^6.9.0",
-				"@wordpress/warning": "^2.32.0",
+				"@wordpress/a11y": "^3.50.0",
+				"@wordpress/compose": "^6.27.0",
+				"@wordpress/date": "^4.50.0",
+				"@wordpress/deprecated": "^3.50.0",
+				"@wordpress/dom": "^3.50.0",
+				"@wordpress/element": "^5.27.0",
+				"@wordpress/escape-html": "^2.50.0",
+				"@wordpress/hooks": "^3.50.0",
+				"@wordpress/html-entities": "^3.50.0",
+				"@wordpress/i18n": "^4.50.0",
+				"@wordpress/icons": "^9.41.0",
+				"@wordpress/is-shallow-equal": "^4.50.0",
+				"@wordpress/keycodes": "^3.50.0",
+				"@wordpress/primitives": "^3.48.0",
+				"@wordpress/private-apis": "^0.32.0",
+				"@wordpress/rich-text": "^6.27.0",
+				"@wordpress/warning": "^2.50.0",
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
@@ -6228,18 +6451,18 @@
 				"dom-scroll-into-view": "^1.2.1",
 				"downshift": "^6.0.15",
 				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^10.11.6",
+				"framer-motion": "^10.13.0",
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
-				"memize": "^1.1.0",
+				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
 				"reakit": "^1.3.11",
-				"remove-accents": "^0.4.2",
+				"remove-accents": "^0.5.0",
 				"use-lilius": "^2.0.1",
-				"uuid": "^8.3.0",
+				"uuid": "^9.0.1",
 				"valtio": "1.7.0"
 			},
 			"engines": {
@@ -6251,9 +6474,9 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/private-apis": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.14.0.tgz",
-			"integrity": "sha512-4F5aCsjWijjq9JjAPUAh0iGnrsRoJNVgQGfOZFND7PMswuaA+uu7xtarKQ5QRsjA1owz2QOv7Hg+MvMuwmG0NA==",
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.32.0.tgz",
+			"integrity": "sha512-P7nxI/bGMDQhtlTfSe1Y2SDfrd20K5UMnTHbq+hmIkzBGRpNPbdGeNu2bZaZtIvmXk1OCR0Fkef+e6QqkOfYPg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -6271,39 +6494,96 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@wordpress/components/node_modules/memize": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
-			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
-			"dev": true
-		},
 		"node_modules/@wordpress/components/node_modules/path-to-regexp": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-			"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
 			"dev": true
 		},
-		"node_modules/@wordpress/components/node_modules/remove-accents": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
-			"integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
-			"dev": true
+		"node_modules/@wordpress/components/node_modules/reakit": {
+			"version": "1.3.11",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
+			"integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
+			"dev": true,
+			"dependencies": {
+				"@popperjs/core": "^2.5.4",
+				"body-scroll-lock": "^3.1.5",
+				"reakit-system": "^0.15.2",
+				"reakit-utils": "^0.15.2",
+				"reakit-warning": "^0.6.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/reakit/node_modules/reakit-system": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+			"integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+			"dev": true,
+			"dependencies": {
+				"reakit-utils": "^0.15.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/reakit/node_modules/reakit-utils": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
+			"dev": true,
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/reakit/node_modules/reakit-warning": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+			"integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+			"dev": true,
+			"dependencies": {
+				"reakit-utils": "^0.15.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "6.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.29.0.tgz",
-			"integrity": "sha512-pL7JhOCDYNCnj3XwkV9jl7901lw/NEaptI6ovF1FTutiFSPeJlrhlZTny9VJpoM9D67Y0x7Q9r+s0exy073oew==",
+			"version": "6.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.33.0.tgz",
+			"integrity": "sha512-q5r+vcpdK2bt4tKTXpLViHESUOmlfvurGFbbdeVVg6P1i9E9RZ7o9rUsdaJcWDDboA2hg4Fkns4/Evb8BO8v0w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/dom": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/keycodes": "^3.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/undo-manager": "^0.12.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/dom": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/keycodes": "^3.56.0",
+				"@wordpress/priority-queue": "^2.56.0",
+				"@wordpress/undo-manager": "^0.16.0",
 				"change-case": "^4.1.2",
 				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
@@ -6314,6 +6594,19 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/compose/node_modules/@wordpress/undo-manager": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.16.0.tgz",
+			"integrity": "sha512-oxlFJ+Q3B5OpblpbvvMf5Qg8hIdIVSaq1SAaVlPgrTOu4Mq1ngjxGQJUin1C/QRD/5si80AE0VpuI9fguk3LPg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/is-shallow-equal": "^4.56.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/core-data": {
@@ -6351,19 +6644,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/core-data/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-			"dev": true,
-			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/block-editor": {
@@ -6426,6 +6706,59 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/blocks": {
+			"version": "12.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.33.0.tgz",
+			"integrity": "sha512-XXxwoVsI6C55YU7RrVYcm//cxIwUNZN+jF9bKR9hA0f4q9W2g/TA3Tbgakj6aHrnQ8/6UGj0Ib+0XmQygK5Qdg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/autop": "^3.56.0",
+				"@wordpress/blob": "^3.56.0",
+				"@wordpress/block-serialization-default-parser": "^4.56.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/data": "^9.26.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/dom": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/hooks": "^3.56.0",
+				"@wordpress/html-entities": "^3.56.0",
+				"@wordpress/i18n": "^4.56.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/rich-text": "^6.33.0",
+				"@wordpress/shortcode": "^3.56.0",
+				"change-case": "^4.1.2",
+				"colord": "^2.7.0",
+				"fast-deep-equal": "^3.1.3",
+				"hpq": "^1.3.0",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"react-is": "^18.2.0",
+				"remove-accents": "^0.5.0",
+				"showdown": "^1.9.1",
+				"simple-html-tokenizer": "^0.5.7",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/components": {
@@ -6492,19 +6825,19 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
+			"version": "9.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.26.0.tgz",
+			"integrity": "sha512-4zL38nhuSvNUGivYqZ3mj9WSWc40szQT7RaRC/Ih+8B7JN5MPGnJMtZ95eTNqqmD1Os9XEMpeG/oOUY+Pt4+/A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/priority-queue": "^2.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/redux-routine": "^4.56.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -6518,6 +6851,18 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/notices": {
@@ -6566,19 +6911,19 @@
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-8.6.0.tgz",
-			"integrity": "sha512-+bQ5dTkJkHeOng3mXXzLBZkudUlOifJql1U99sWGbtLarU/yjfF0ldi/a6uR1cVvDJkGizDYHf9vv/nA39Oaqw==",
+			"version": "9.5.6",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.5.6.tgz",
+			"integrity": "sha512-ab+B0UbiF8CAGR/lsVmj93Obpw0Wfnjj70Zufqeznm34b3n1fpyDlG/lJt9VKUyQWdTgTGL0rLvxwHpd3cvs4g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.6.0",
-				"@wordpress/deprecated": "^3.29.0",
-				"@wordpress/element": "^5.6.0",
-				"@wordpress/is-shallow-equal": "^4.29.0",
-				"@wordpress/priority-queue": "^2.29.0",
-				"@wordpress/private-apis": "^0.11.0",
-				"@wordpress/redux-routine": "^4.29.0",
+				"@wordpress/compose": "^6.12.3",
+				"@wordpress/deprecated": "^3.35.2",
+				"@wordpress/element": "^5.12.2",
+				"@wordpress/is-shallow-equal": "^4.35.2",
+				"@wordpress/priority-queue": "^2.35.2",
+				"@wordpress/private-apis": "^0.17.3",
+				"@wordpress/redux-routine": "^4.35.2",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -6595,9 +6940,9 @@
 			}
 		},
 		"node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.11.0.tgz",
-			"integrity": "sha512-GpAZ34Ou9YkYi9fuJCb9oDIZhsLqj41stuHflxpTNih6vV/Qw7ApBkLZDhDCyWjOybnjtHQH1LWw3K3RCN4miw==",
+			"version": "0.17.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.17.3.tgz",
+			"integrity": "sha512-D2qjamJf1OwIIjJHShk+lC+nU9pCRd70+x8qx6ZIbbU7xXT/bl+9IvWseMLoT12QW3ReQNcvzNMP7Uds+tcphw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -6616,13 +6961,13 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "4.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.52.0.tgz",
-			"integrity": "sha512-NpnQB4UDMAR+U8DFdvSBMRT1A/haqP7WRjUk1lMfIO/plLmLb7YrdOhN9fUs24WXOJk9aBWQwm3hWQRHPZOQlw==",
+			"version": "4.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.56.0.tgz",
+			"integrity": "sha512-ic0HuZ4BR7xdTVoqVXwFfxZYOmxfjLH/P/4gh/rSdCOoEJo239/uIznZByZf3ZCPVSkK5stZ4qgJQ6YQTTM32w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^3.52.0",
+				"@wordpress/deprecated": "^3.56.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -6631,9 +6976,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-5.3.0.tgz",
-			"integrity": "sha512-UhLiv4by3FLr8+PFOsFDFqpNn8Mdhz4MI1A/CiTYCUVcONtu4qO1w5zAl2tpw39Xh7PVHiaFZPb1iW/wLgSw3A==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-5.7.0.tgz",
+			"integrity": "sha512-s/xUnAEKwXmSUZLqrvX4n3tBWegxaiQfXJwd264MRJUmz4JibWJnvevkxM6tooEetu36xGiVHAIPvfvEEEtntQ==",
 			"dev": true,
 			"dependencies": {
 				"json2php": "^0.0.7"
@@ -6646,35 +6991,35 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.52.0.tgz",
-			"integrity": "sha512-OHO8S/dX6xd7OZ093R6r/kK3OLUeeABLu3OoTULOOn4dS2folENMNMpleH78KY0MuQbBQlPgdtMqbSRKZHdJgQ==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.56.0.tgz",
+			"integrity": "sha512-7L59mZPzth3xZqL/MdIMWZjKc4muQjQH7U6ZAP9ur4YVnosAhMBKkNRaUQwMVyr9ZjT1xd/Cpl3ukcdlsfhbQw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.52.0"
+				"@wordpress/hooks": "^3.56.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.52.0.tgz",
-			"integrity": "sha512-eAoQy2cSmRP07SlhfRM7r8vkKBgnSla0074EkEXgQgYs6whGdH6MOp8mtd2ExkzTToXYRuIHh7f+rNBKNyxRtQ==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.56.0.tgz",
+			"integrity": "sha512-Ty9av6A9mH+1loT2OHpdBtawlYzmqF8lzebN54HY2gp1gUnpYQiBi5iKbDYuiEKQukfaSsX/PtqYgWx18UCiCg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^3.52.0"
+				"@wordpress/deprecated": "^3.56.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.52.0.tgz",
-			"integrity": "sha512-xJEGle5naOwO27Z+22kpjWAWqrZClLHGem+5KsGVUwbk2Lde/pBj/C8rlmQGNHx9mGwV0BVR5+QPvoTiMt8RMQ==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.56.0.tgz",
+			"integrity": "sha512-f/NMkDLxBOlQ905mMOKjJNhIdiZjlJ/BdcRTxtK1MwnA91lTSVZigEw4eXApU1fK86brZ8LD5Sg5YgD+NrYQzA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -6684,14 +7029,14 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.20.0.tgz",
-			"integrity": "sha512-wNVXeoeJQl2Xny8K578e6VMBYyHchOLAEO4YETARn5DNmt+6jUjAS3xIB9mpn+nJuaUZujROc38Z3IVD22rbAA==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.24.0.tgz",
+			"integrity": "sha512-r/lTk9y3rmoKASZ1Bn+vYtv5Xw0e3RxT8nXJIpM0eaHmRxTg7u7aHvIVEfi6ZDAKWuuywoCDP/KAdy9FR3lhDQ==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/api-fetch": "^6.49.0",
-				"@wordpress/keycodes": "^3.52.0",
-				"@wordpress/url": "^3.53.0",
+				"@wordpress/api-fetch": "^6.53.0",
+				"@wordpress/keycodes": "^3.56.0",
+				"@wordpress/url": "^3.57.0",
 				"change-case": "^4.1.2",
 				"form-data": "^4.0.0",
 				"get-port": "^5.1.1",
@@ -6707,14 +7052,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.29.0.tgz",
-			"integrity": "sha512-PG8HbdwL4Gq8wp2EIrTOTz+C7jsghzfQPu8NgbBz74oPXE+qjhrAGT39XyxHqZO/pvEwyZpdIzFyx9uYoED2jw==",
+			"version": "5.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.33.0.tgz",
+			"integrity": "sha512-RNisHbRgAO5/RLyfckgHYWgKq+IKd8Yn1mJHYWp+1Fx+1K6vjlhr/1D4a81fWL15IoCTV3tYh6zYei4/fRpZog==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/react": "^18.0.21",
 				"@types/react-dom": "^18.0.6",
-				"@wordpress/escape-html": "^2.52.0",
+				"@wordpress/escape-html": "^2.56.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.2.0",
@@ -6733,9 +7078,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "2.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.52.0.tgz",
-			"integrity": "sha512-0h5gn9QK+yP7WbhW4rsB2irvfdqsB5/9WFc4D9QSt2nVmC+Wf4KCTCPh6WilV0OApi+Se8TrV1tZwedhuCDqlw==",
+			"version": "2.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.56.0.tgz",
+			"integrity": "sha512-f+NDe9ZyUtaoiU8VYSKRjxsKqqzinrVcpcqj+umiLhKD5ShGW8V7LcSr3JOdE4TgjHvw2eezFvRmEo/kXowmMA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -6744,16 +7089,16 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "17.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.9.0.tgz",
-			"integrity": "sha512-vPDxa5TwidfU0B3DMxje0Xv2fHT8tY/ar9i305y7oH2ug86RKFo62JZ2lUAA5g+eUCCA+ZV/pLO8lSZo9w3XEQ==",
+			"version": "17.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.13.0.tgz",
+			"integrity": "sha512-QnG5HmOd+XsweKOvrqbOugm9rINUjcsh1jo2SN4cbbTWZJ6nPmcfLS0YJdrKkgOQUnKDPQgBPVEyI8tp19OtBw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^7.36.0",
-				"@wordpress/prettier-config": "^3.9.0",
+				"@wordpress/babel-preset-default": "^7.40.0",
+				"@wordpress/prettier-config": "^3.13.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
@@ -6784,6 +7129,214 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/type-utils": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/parser": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+			"integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/cosmiconfig": {
@@ -6817,6 +7370,68 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dev": true,
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/type-fest": {
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -6829,6 +7444,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/yaml": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
@@ -6839,9 +7460,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.52.0.tgz",
-			"integrity": "sha512-acEF5B6GkFOjImqPpLvl1lP0sbpS6h35BV6RbXZFlaawCj8GYs6/tvCkHXzfwvjGwP2aR9jdpSx9DpXWKyJSQQ==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.56.0.tgz",
+			"integrity": "sha512-sxoNbXdqfhlRNduDqR5y5Cq7Rwm5ATZGIr5U9nrM5RHWd+8v7g8wpB/rpTSqi+HeCW3suiFuN6qJJZ4eFwRB2w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -6851,9 +7472,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.52.0.tgz",
-			"integrity": "sha512-wL9utg0ukbvKHX3nPRApvVnij6+8Wen1SgBiQzQwh+3SNpJdI5RsYDH0dlUnI4RZw3tmi7t21ZOAOYA1oZiyKw==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.56.0.tgz",
+			"integrity": "sha512-hWP0p/Q20YNQYOw3wfL2Vu22jcYbV9osbbiTBXQ5F4/ZDscIfEKwVkP8V5DSNEYlF4e0KuDMPe5eBykWX/ofLg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -6863,13 +7484,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "4.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.52.0.tgz",
-			"integrity": "sha512-0fCE5v59SvDkhX6xy7jLav8W3y2IMMp0F3Muvn4m0F1DbPWRQYAqqfsAh3g/0qYqVuLf089JIDc/w2E/GK0e5Q==",
+			"version": "4.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.56.0.tgz",
+			"integrity": "sha512-W+WL8vxwqUeicgXvIHZ3Htq6pYrJe2Dn/9SBsQ7gFPUrGWe2ww5IzPocLv4rAha3lca2ZVIX2q47rGaSs9t8Kw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.52.0",
+				"@wordpress/hooks": "^3.56.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -6883,48 +7504,22 @@
 			}
 		},
 		"node_modules/@wordpress/icons": {
-			"version": "9.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.43.0.tgz",
-			"integrity": "sha512-pzJeY2I58p/5XpnwWEpj2FwQMQdwerhPotcaFENKGyhu1NjBGG4djuiZhwGNyS9IAmzS/wsI1yObZb+1kBBCdA==",
+			"version": "9.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.47.0.tgz",
+			"integrity": "sha512-IQIoEr0LxPWUOgcHnMIqU/ytg3x/swxbl8AGG1ONFks3/2tYdDk3I2/CAYgQGpaiSFIOJjNVk1keqa8DBOnciw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/primitives": "^3.50.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wordpress/interactivity": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-5.1.0.tgz",
-			"integrity": "sha512-F/ffYPLKwxXFs0VstjJ4+BZmVfQbD0174yGci9aAEn1DfsglLHu7SjM9U+CuatwDCWeDsuPNfy0iEuRurhP8CA==",
-			"dev": true,
-			"dependencies": {
-				"@preact/signals": "^1.2.2",
-				"deepsignal": "^1.4.0",
-				"preact": "^10.19.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wordpress/interactivity-router": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-1.2.0.tgz",
-			"integrity": "sha512-lPo9jcfrCho9U7UYNpdSiIQzf4BtXiF/Rv5urrXins0ati5TucYJyfWrs9rkp3yxZV7Z/LCGUE7tMPST+UZynw==",
-			"dev": true,
-			"dependencies": {
-				"@wordpress/interactivity": "^5.1.0"
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/primitives": "^3.54.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "4.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.52.0.tgz",
-			"integrity": "sha512-5VpPrnTbWt27I2RJTSyZe8NUrs4MRRIHjvmNLXV9LDWDnttdxtA3p171xkR/VquEr8lDGdl/IeCEuTji/HegpA==",
+			"version": "4.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.56.0.tgz",
+			"integrity": "sha512-lwDDqWuK5gtaL/avECX6dd29qoX1MmE0c9iDT64lBHGAVkYPZu6z31HycvRrEbzM5nbn/C2SU542qqqy/MzNoA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
@@ -6934,9 +7529,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.23.0.tgz",
-			"integrity": "sha512-5f2z6Z9WMKu9T3TDQAtpqvPItWRIlUXOlTJXPIYiFktxguhSHU7Q6i8vXKA/lXs6DxNAlxl8n+pRk7S68TSJtQ==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.27.0.tgz",
+			"integrity": "sha512-mzKShc0zUHyWsHt/fK2L3cJDWWAp9AttzENDTo7RuynqJWTDOGsqsnDr6zITyVcaL0my8ApVTiWu5OxzBXXvfg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -6950,12 +7545,12 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "11.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.23.0.tgz",
-			"integrity": "sha512-murMNev+bT+CuJR++0NcZDFovZiY5Hbnh9aAAZ+BbS+Q6E42eTIO1fONxeN9QuvrYm/8LznMszWxzgGs4Wmtsw==",
+			"version": "11.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.27.0.tgz",
+			"integrity": "sha512-5fyyKthW+BNpv+Ndtgl2+1uHsmEWqTtf3PN+FL3qRfYCTPbvasxZBkGx2bpnt0D9ajcrpGmbllwOoM0dhY8Q6w==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/jest-console": "^7.23.0",
+				"@wordpress/jest-console": "^7.27.0",
 				"babel-jest": "^29.6.2"
 			},
 			"engines": {
@@ -7024,74 +7619,36 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.52.0.tgz",
-			"integrity": "sha512-Qz+hdTtTZCBNgnhWb/pzM7iMfhx+bwo/b0LmTbANU4i4wJBaKQ9Qlkkaek30gZ/qC7rHunTtXoupcJ5NrZZdtg==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.56.0.tgz",
+			"integrity": "sha512-YIvqB0AEsu3fjkuQHNT7XladaTDE1Thntv+oqzkRejdNodH5tbPb3CAePAK3F7iQurZ0GCaqlmJTy9qcHwDU0Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.52.0"
+				"@wordpress/i18n": "^4.56.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/notices": {
-			"version": "3.31.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.31.0.tgz",
-			"integrity": "sha512-9WyaFaSr/vQc1K7cZLyPw1xBKqWfjpAKMJzWMzHYjwk1ldibhBWVLukicuolD6Y+9l+97IZHCoESBQwUeFo79Q==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.3.6.tgz",
+			"integrity": "sha512-aJNBsTy6VgKx1QQT6+3I1H8qDbE1EvwPWGo7EfJNrvJTmynO6xp6sO3pvT+e9l7x9MaqVopjN6Up4ykKhQYt7Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^3.31.0",
-				"@wordpress/data": "^9.1.0"
+				"@wordpress/a11y": "^3.35.2",
+				"@wordpress/data": "^9.5.6"
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
-				"deepmerge": "^4.3.0",
-				"equivalent-key-map": "^0.2.2",
-				"is-plain-object": "^5.0.0",
-				"is-promise": "^4.0.0",
-				"redux": "^4.1.2",
-				"rememo": "^4.0.2",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "4.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.37.0.tgz",
-			"integrity": "sha512-a0+oP4y/9TgPCzhaVXrhNKPfvZ+eHAZKlid5gvveM9A4HYVdeaw8m7eyH7CxBUJdG/GjOPvtw//KMqu+ijxbIg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.41.0.tgz",
+			"integrity": "sha512-HStjqoxdB4zTU9i3BCzvbI0OyVZ3L6phSeoRwk2uU1cT41O883ouoBGE9DcEIzufKeuFCeqCBJf8NRk8S2h/sg==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -7100,256 +7657,13 @@
 				"npm-package-json-lint": ">=6.0.0"
 			}
 		},
-		"node_modules/@wordpress/patterns": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-1.13.0.tgz",
-			"integrity": "sha512-jpCy7lFzSDpHWaYA4LiHZ7v019k7lanJKTNhavCmZCln8lixbsmZClGzQaBRbSfn23CiBsEVyJo1Nnp+bEEVbw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^3.52.0",
-				"@wordpress/block-editor": "^12.20.0",
-				"@wordpress/blocks": "^12.29.0",
-				"@wordpress/components": "^27.0.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/core-data": "^6.29.0",
-				"@wordpress/data": "^9.22.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/html-entities": "^3.52.0",
-				"@wordpress/i18n": "^4.52.0",
-				"@wordpress/icons": "^9.43.0",
-				"@wordpress/notices": "^4.20.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/url": "^3.53.0",
-				"nanoid": "^3.3.4"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/patterns/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-			"dev": true,
-			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
-			}
-		},
-		"node_modules/@wordpress/patterns/node_modules/@wordpress/block-editor": {
-			"version": "12.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.20.0.tgz",
-			"integrity": "sha512-3Ahg8FZo9Og9lNyUZ9dPXnXn/lumlqyV/D2Bd0h0MidYM9VZai0n8qyWrWmoF11/lwzRYVdr9J8bxWDB0xKGAg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@emotion/react": "^11.7.1",
-				"@emotion/styled": "^11.6.0",
-				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^3.52.0",
-				"@wordpress/api-fetch": "^6.49.0",
-				"@wordpress/blob": "^3.52.0",
-				"@wordpress/blocks": "^12.29.0",
-				"@wordpress/commands": "^0.23.0",
-				"@wordpress/components": "^27.0.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/data": "^9.22.0",
-				"@wordpress/date": "^4.52.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/dom": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/escape-html": "^2.52.0",
-				"@wordpress/hooks": "^3.52.0",
-				"@wordpress/html-entities": "^3.52.0",
-				"@wordpress/i18n": "^4.52.0",
-				"@wordpress/icons": "^9.43.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/keyboard-shortcuts": "^4.29.0",
-				"@wordpress/keycodes": "^3.52.0",
-				"@wordpress/notices": "^4.20.0",
-				"@wordpress/preferences": "^3.29.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/rich-text": "^6.29.0",
-				"@wordpress/style-engine": "^1.35.0",
-				"@wordpress/token-list": "^2.52.0",
-				"@wordpress/url": "^3.53.0",
-				"@wordpress/warning": "^2.52.0",
-				"@wordpress/wordcount": "^3.52.0",
-				"change-case": "^4.1.2",
-				"classnames": "^2.3.1",
-				"colord": "^2.7.0",
-				"deepmerge": "^4.3.0",
-				"diff": "^4.0.2",
-				"fast-deep-equal": "^3.1.3",
-				"memize": "^2.1.0",
-				"postcss": "^8.4.21",
-				"postcss-prefixwrap": "^1.41.0",
-				"postcss-urlrebase": "^1.0.0",
-				"react-autosize-textarea": "^7.1.0",
-				"react-easy-crop": "^4.5.1",
-				"rememo": "^4.0.2",
-				"remove-accents": "^0.5.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/patterns/node_modules/@wordpress/components": {
-			"version": "27.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-27.0.0.tgz",
-			"integrity": "sha512-IELZjV2AOJ8+qtu4iiub2NtErojiX5E3RGrDqlxABRKswRh4R0lXuuer63lRI5MMWFndbyJjjOuUmt42FQXifw==",
-			"dev": true,
-			"dependencies": {
-				"@ariakit/react": "^0.3.12",
-				"@babel/runtime": "^7.16.0",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^2.0.8",
-				"@types/gradient-parser": "0.1.3",
-				"@types/highlight-words-core": "1.2.1",
-				"@use-gesture/react": "^10.2.24",
-				"@wordpress/a11y": "^3.52.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/date": "^4.52.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/dom": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/escape-html": "^2.52.0",
-				"@wordpress/hooks": "^3.52.0",
-				"@wordpress/html-entities": "^3.52.0",
-				"@wordpress/i18n": "^4.52.0",
-				"@wordpress/icons": "^9.43.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/keycodes": "^3.52.0",
-				"@wordpress/primitives": "^3.50.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/rich-text": "^6.29.0",
-				"@wordpress/warning": "^2.52.0",
-				"change-case": "^4.1.2",
-				"classnames": "^2.3.1",
-				"colord": "^2.7.0",
-				"date-fns": "^2.28.0",
-				"deepmerge": "^4.3.0",
-				"downshift": "^6.0.15",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^10.13.0",
-				"gradient-parser": "^0.1.5",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
-				"remove-accents": "^0.5.0",
-				"use-lilius": "^2.0.1",
-				"uuid": "^9.0.1",
-				"valtio": "1.7.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/patterns/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
-				"deepmerge": "^4.3.0",
-				"equivalent-key-map": "^0.2.2",
-				"is-plain-object": "^5.0.0",
-				"is-promise": "^4.0.0",
-				"redux": "^4.1.2",
-				"rememo": "^4.0.2",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/patterns/node_modules/@wordpress/notices": {
-			"version": "4.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.20.0.tgz",
-			"integrity": "sha512-lsIiqUotHdFWJUXGTidzACMVLd5xirQIq7SGfg5ApGYXkfEzOY1+4X2b5JtbvEKxGYXRqyL7ET4BozG/Uki6SQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^3.52.0",
-				"@wordpress/data": "^9.22.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/patterns/node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@wordpress/patterns/node_modules/path-to-regexp": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-			"integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-			"dev": true
-		},
-		"node_modules/@wordpress/patterns/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "4.36.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.36.0.tgz",
-			"integrity": "sha512-J4wOnzrI1MZpzVoLQbMn0539B7vuAiEkUOeZ28VnKsb9WSYQ+hTKkfco0gz76WtE0p5oquy22vRVilslckRL2g==",
+			"version": "4.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.40.0.tgz",
+			"integrity": "sha512-xnd+XZI5s9hyGtt314WgH3prxQVBMLEjmTTz0g1+9x1avrYxIwhv1ZxMNittrAq2IP1qBzT5IwsPzJ+wCgcEyw==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/base-styles": "^4.43.0",
+				"@wordpress/base-styles": "^4.47.0",
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
@@ -7383,19 +7697,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/preferences/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-			"dev": true,
-			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
@@ -7519,9 +7820,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.9.0.tgz",
-			"integrity": "sha512-CUCAZAAFDYgE6JG6x8U/kJ94tMyKkeRyNNcbPHK/R4oR+9T1bTbT2rWVQ9VFC2M6yNEP7uwZU9ufdYcSn5bq7g==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.13.0.tgz",
+			"integrity": "sha512-oNayHsdAhP3ER4T7KjNrmdtEIZjYJAdIDdScjNOKmK3Qvp02VP9TPfDGhLSjiYmOiQcyrIz/uuf9MJ9JCcdGng==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
@@ -7531,12 +7832,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.50.0.tgz",
-			"integrity": "sha512-3HauFtTv3jiQlDebhM2K2ZQNSAwlIqZH0Xf2eHEXdSMLY3kA5yfb1aMStqexe397PpOLLhhcunwbXQ2FBhTilw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.54.0.tgz",
+			"integrity": "sha512-2TrXDvYW3V0nlq6ZCYYvJ5obPZNtrsuIdB0iLdUavCOSBoXTROhRZY9Pxz45bB2CLlmEUs9OfL7izx9IuAg4Mw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^5.29.0",
+				"@wordpress/element": "^5.33.0",
 				"classnames": "^2.3.1"
 			},
 			"engines": {
@@ -7544,9 +7845,9 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "2.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.52.0.tgz",
-			"integrity": "sha512-umajVlF6/T7c81bP5Gl5teQyKAPX0/ilbTyQKsa1iyWsGir/E7sZ9l7mTMuJJ2CkrSl3m3YpV8shfwjMy6EVlQ==",
+			"version": "2.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.56.0.tgz",
+			"integrity": "sha512-uwQW6RN7xXo7ZOOm4tPkvvAE1pOG8Umo6m95KKy0myQbacDuUfkPZEjq2wAOlRcSjuYyNJkrtjqOdr8Z7eFBsw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -7569,9 +7870,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "4.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.52.0.tgz",
-			"integrity": "sha512-+X/4bxJRxdzvSKXLYWxaNnULp8SHFL0V3m4+FYMJoCENzFXlVUexZNGw7zRThov/TkZaX45bqp8f3YWAZBV3EA==",
+			"version": "4.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.56.0.tgz",
+			"integrity": "sha512-wwg7SXKYt8rV/PZjEtoETSJjVnNwnhLrwczl+tch2FXGlkwtSTblSwhkMyyLE6Y628LQs9m9MUWAvXrJ5SCPlQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -7620,19 +7921,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/reusable-blocks/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-			"dev": true,
-			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/block-editor": {
@@ -7695,6 +7983,59 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/blocks": {
+			"version": "12.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.33.0.tgz",
+			"integrity": "sha512-XXxwoVsI6C55YU7RrVYcm//cxIwUNZN+jF9bKR9hA0f4q9W2g/TA3Tbgakj6aHrnQ8/6UGj0Ib+0XmQygK5Qdg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/autop": "^3.56.0",
+				"@wordpress/blob": "^3.56.0",
+				"@wordpress/block-serialization-default-parser": "^4.56.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/data": "^9.26.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/dom": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/hooks": "^3.56.0",
+				"@wordpress/html-entities": "^3.56.0",
+				"@wordpress/i18n": "^4.56.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/rich-text": "^6.33.0",
+				"@wordpress/shortcode": "^3.56.0",
+				"change-case": "^4.1.2",
+				"colord": "^2.7.0",
+				"fast-deep-equal": "^3.1.3",
+				"hpq": "^1.3.0",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"react-is": "^18.2.0",
+				"remove-accents": "^0.5.0",
+				"showdown": "^1.9.1",
+				"simple-html-tokenizer": "^0.5.7",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
@@ -7761,19 +8102,19 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
+			"version": "9.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.26.0.tgz",
+			"integrity": "sha512-4zL38nhuSvNUGivYqZ3mj9WSWc40szQT7RaRC/Ih+8B7JN5MPGnJMtZ95eTNqqmD1Os9XEMpeG/oOUY+Pt4+/A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/priority-queue": "^2.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/redux-routine": "^4.56.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -7787,6 +8128,18 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices": {
@@ -7835,22 +8188,21 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "6.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.29.0.tgz",
-			"integrity": "sha512-gsXxaEDeNnRO/s7gbaouK8mqjN5JMputb6t82XxfrnuhQ7TcYxS5jkARn530RR832sPtRZX/bvT3LHI0Rw8sQQ==",
+			"version": "6.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.33.0.tgz",
+			"integrity": "sha512-+JOkWAtAjRleZ3NwPDuro/HNFGsIXR0BniZnF+lUJs9MDdi5BQMrR8oeOzGuVsc5uRFTQFRHIhe0tpSgDgfFxg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^3.52.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/data": "^9.22.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/escape-html": "^2.52.0",
-				"@wordpress/i18n": "^4.52.0",
-				"@wordpress/keycodes": "^3.52.0",
-				"memize": "^2.1.0",
-				"rememo": "^4.0.2"
+				"@wordpress/a11y": "^3.56.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/data": "^9.26.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/escape-html": "^2.56.0",
+				"@wordpress/i18n": "^4.56.0",
+				"@wordpress/keycodes": "^3.56.0",
+				"memize": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -7860,19 +8212,19 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
+			"version": "9.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.26.0.tgz",
+			"integrity": "sha512-4zL38nhuSvNUGivYqZ3mj9WSWc40szQT7RaRC/Ih+8B7JN5MPGnJMtZ95eTNqqmD1Os9XEMpeG/oOUY+Pt4+/A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/priority-queue": "^2.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/redux-routine": "^4.56.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -7888,6 +8240,18 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@wordpress/rich-text/node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -7898,24 +8262,24 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "27.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-27.3.0.tgz",
-			"integrity": "sha512-PMIFMsjsEpXfgioc1413z7TTD+pq5F9nOoV1Ygvhv/aDImgfeYmMW9VNytETDsUtJ6yRWBi+TWREW9tChbfPhw==",
+			"version": "27.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-27.7.0.tgz",
+			"integrity": "sha512-dFkye4tO3xbFbqi1RMgiicykT074C2VuenT9Kc1L9oUwFmHa4BVDskcNIMKWl3CzDb2gtNEjsZx77CMQTzgLAQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^7.36.0",
-				"@wordpress/browserslist-config": "^5.35.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^5.3.0",
-				"@wordpress/e2e-test-utils-playwright": "^0.20.0",
-				"@wordpress/eslint-plugin": "^17.9.0",
-				"@wordpress/jest-preset-default": "^11.23.0",
-				"@wordpress/npm-package-json-lint-config": "^4.37.0",
-				"@wordpress/postcss-plugins-preset": "^4.36.0",
-				"@wordpress/prettier-config": "^3.9.0",
-				"@wordpress/stylelint-config": "^21.35.0",
+				"@wordpress/babel-preset-default": "^7.40.0",
+				"@wordpress/browserslist-config": "^5.39.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^5.7.0",
+				"@wordpress/e2e-test-utils-playwright": "^0.24.0",
+				"@wordpress/eslint-plugin": "^17.13.0",
+				"@wordpress/jest-preset-default": "^11.27.0",
+				"@wordpress/npm-package-json-lint-config": "^4.41.0",
+				"@wordpress/postcss-plugins-preset": "^4.40.0",
+				"@wordpress/prettier-config": "^3.13.0",
+				"@wordpress/stylelint-config": "^21.39.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "^29.6.2",
 				"babel-loader": "^8.2.3",
@@ -7943,7 +8307,6 @@
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
-				"playwright-core": "1.39.0",
 				"postcss": "^8.4.5",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
@@ -7970,7 +8333,7 @@
 				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.39.0",
+				"@playwright/test": "^1.43.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -8017,17 +8380,57 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/server-side-render/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/blocks": {
+			"version": "12.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.33.0.tgz",
+			"integrity": "sha512-XXxwoVsI6C55YU7RrVYcm//cxIwUNZN+jF9bKR9hA0f4q9W2g/TA3Tbgakj6aHrnQ8/6UGj0Ib+0XmQygK5Qdg==",
 			"dev": true,
 			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/autop": "^3.56.0",
+				"@wordpress/blob": "^3.56.0",
+				"@wordpress/block-serialization-default-parser": "^4.56.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/data": "^9.26.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/dom": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/hooks": "^3.56.0",
+				"@wordpress/html-entities": "^3.56.0",
+				"@wordpress/i18n": "^4.56.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/rich-text": "^6.33.0",
+				"@wordpress/shortcode": "^3.56.0",
+				"change-case": "^4.1.2",
+				"colord": "^2.7.0",
+				"fast-deep-equal": "^3.1.3",
+				"hpq": "^1.3.0",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"react-is": "^18.2.0",
+				"remove-accents": "^0.5.0",
+				"showdown": "^1.9.1",
+				"simple-html-tokenizer": "^0.5.7",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=12"
 			},
 			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
@@ -8094,19 +8497,19 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/data": {
-			"version": "9.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.22.0.tgz",
-			"integrity": "sha512-gYnX8sXFO2GasXG2S9ahkClCChw8vp1IKllPVSkIdHDR/EMKA9VZSGNi6qEPtxD+XNdoUdhn7unXsCzZCSI9uQ==",
+			"version": "9.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.26.0.tgz",
+			"integrity": "sha512-4zL38nhuSvNUGivYqZ3mj9WSWc40szQT7RaRC/Ih+8B7JN5MPGnJMtZ95eTNqqmD1Os9XEMpeG/oOUY+Pt4+/A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^6.29.0",
-				"@wordpress/deprecated": "^3.52.0",
-				"@wordpress/element": "^5.29.0",
-				"@wordpress/is-shallow-equal": "^4.52.0",
-				"@wordpress/priority-queue": "^2.52.0",
-				"@wordpress/private-apis": "^0.34.0",
-				"@wordpress/redux-routine": "^4.52.0",
+				"@wordpress/compose": "^6.33.0",
+				"@wordpress/deprecated": "^3.56.0",
+				"@wordpress/element": "^5.33.0",
+				"@wordpress/is-shallow-equal": "^4.56.0",
+				"@wordpress/priority-queue": "^2.56.0",
+				"@wordpress/private-apis": "^0.38.0",
+				"@wordpress/redux-routine": "^4.56.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -8120,6 +8523,18 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.38.0.tgz",
+			"integrity": "sha512-GZqq4UrYeFCoQ4UxPzRAhpdVslDnHM3JsvfMIeCZbBgQKTinhKGdpXFcVE6aaLlr7wvwvRPSkdy+vG0FgQQ/8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/is-plain-object": {
@@ -8151,9 +8566,9 @@
 			}
 		},
 		"node_modules/@wordpress/shortcode": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.52.0.tgz",
-			"integrity": "sha512-Uyf0dbGW0C3OnvWMhEXSHlWK/AEs8C8cEjG6UBe0jdphXaTHF8ZPqP9zEIIOL93c/Netg79MxUadav0kuBlkJg==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.56.0.tgz",
+			"integrity": "sha512-0e7byjsok+OTIaS973Ngf6Lzy9dyEAlUk7ZjuDVGbWKjlLZGTvr5Y+ioPgnE0Uq/DWhXWpTG9gXZr2Rf4PXdng==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -8177,9 +8592,9 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "21.35.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.35.0.tgz",
-			"integrity": "sha512-/nsiyxEQUqicwVW/LYBFW3fmkzmbbtUSNpWYRGxPuEmBP0NG7BFmjWGt37k1gm0m0JX55KIQzxbU0o56wBRD8w==",
+			"version": "21.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.39.0.tgz",
+			"integrity": "sha512-MNFsOpriCtNXs1TfPQwPkU7/4Jo0e0IfGJdvRYHp8mSv0VqY1vn9CW8QJ8xqrWYqxCOG6Z+Zn9IPToEM5mqz5A==",
 			"dev": true,
 			"dependencies": {
 				"stylelint-config-recommended": "^6.0.0",
@@ -8239,9 +8654,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.53.0.tgz",
-			"integrity": "sha512-jMY6frxKQUizZRpFPcLx3hivdSH9Ty+E5CIE26lf0Xd3uKTFE1CS3uY+cuNXY+w9/EZZBKHZK4jq7AEOSR8qUg==",
+			"version": "3.57.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.57.0.tgz",
+			"integrity": "sha512-W3F0KVEaMoRENya7GGUPXrZGYnhAg3fuLSLpNcf1skSrM5rUVMNdeRlZj+jln1O/+qjboJnC+y+IzOlQRwlS6A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -8308,9 +8723,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "2.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.53.0.tgz",
-			"integrity": "sha512-53O09aUJgEuGcCVTHQcxvqjeU79rHF6fw9VSZwv6lYfZTwwtxwMHGPF6hUp12NeR+bqYGsUz2Ls6gzSHaAE2Zw==",
+			"version": "2.56.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.56.0.tgz",
+			"integrity": "sha512-Bd1Zy5eWQPKoQsfQwD9T1KZWPpq+ZFyozirx+Z5MnX59J0i80p8KiEMcmXhPH+Os9An2PtlVV9j0gY9z5z0oAw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -8995,9 +9410,9 @@
 			"dev": true
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.17",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
-			"integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
+			"version": "10.4.19",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+			"integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
 			"dev": true,
 			"funding": [
 				{
@@ -9014,8 +9429,8 @@
 				}
 			],
 			"dependencies": {
-				"browserslist": "^4.22.2",
-				"caniuse-lite": "^1.0.30001578",
+				"browserslist": "^4.23.0",
+				"caniuse-lite": "^1.0.30001599",
 				"fraction.js": "^4.3.7",
 				"normalize-range": "^0.1.2",
 				"picocolors": "^1.0.0",
@@ -9217,13 +9632,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
-			"integrity": "sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==",
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
+			"integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.5.0",
+				"@babel/helper-define-polyfill-provider": "^0.6.2",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -9231,25 +9646,25 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
-			"integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz",
+			"integrity": "sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.5.0",
-				"core-js-compat": "^3.34.0"
+				"@babel/helper-define-polyfill-provider": "^0.6.1",
+				"core-js-compat": "^3.36.1"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
-			"integrity": "sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
+			"integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.5.0"
+				"@babel/helper-define-polyfill-provider": "^0.6.2"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -9301,9 +9716,9 @@
 			"dev": true
 		},
 		"node_modules/bare-events": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.0.tgz",
-			"integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
+			"integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -9328,9 +9743,9 @@
 			]
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
-			"integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -9568,9 +9983,9 @@
 			}
 		},
 		"node_modules/builtins": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-			"integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-5.1.0.tgz",
+			"integrity": "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==",
 			"dev": true,
 			"dependencies": {
 				"semver": "^7.0.0"
@@ -9706,9 +10121,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001589",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
-			"integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
+			"version": "1.0.30001614",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001614.tgz",
+			"integrity": "sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==",
 			"dev": true,
 			"funding": [
 				{
@@ -10420,9 +10835,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.36.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.0.tgz",
-			"integrity": "sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw==",
+			"version": "3.37.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
+			"integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -10431,12 +10846,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.36.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.0.tgz",
-			"integrity": "sha512-iV9Pd/PsgjNWBXeq8XRtWVSgz2tKAfhfvBs7qxYty+RlRd+OCksaWmOnc4JKrTc1cToXL1N0s3l/vwlxPtdElw==",
+			"version": "3.37.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
+			"integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.22.3"
+				"browserslist": "^4.23.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -10577,9 +10992,9 @@
 			"dev": true
 		},
 		"node_modules/css-declaration-sorter": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.1.1.tgz",
-			"integrity": "sha512-dZ3bVTEEc1vxr3Bek9vGwfB5Z6ESPULhcRvO472mfjVnj8jRcTnKO8/JTczlvxM10Myb+wBM++1MtdO76eWcaQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
+			"integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
 			"dev": true,
 			"engines": {
 				"node": "^14 || ^16 || >=18"
@@ -10719,12 +11134,12 @@
 			}
 		},
 		"node_modules/cssnano": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.5.tgz",
-			"integrity": "sha512-tpTp/ukgrElwu3ESFY4IvWnGn8eTt8cJhC2aAbtA3lvUlxp6t6UPv8YCLjNnEGiFreT1O0LiOM1U3QyTBVFl2A==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.1.2.tgz",
+			"integrity": "sha512-rYk5UeX7VAM/u0lNqewCdasdtPK81CgX8wJFLEIXHbV2oldWRgJAsZrdhRXkV1NJzA2g850KiFm9mMU2HxNxMA==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-preset-default": "^6.0.5",
+				"cssnano-preset-default": "^6.1.2",
 				"lilconfig": "^3.1.1"
 			},
 			"engines": {
@@ -10739,40 +11154,41 @@
 			}
 		},
 		"node_modules/cssnano-preset-default": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.5.tgz",
-			"integrity": "sha512-M+qRDEr5QZrfNl0B2ySdbTLGyNb8kBcSjuwR7WBamYBOEREH9t2efnB/nblekqhdGLZdkf4oZNetykG2JWRdZQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.1.2.tgz",
+			"integrity": "sha512-1C0C+eNaeN8OcHQa193aRgYexyJtU8XwbdieEjClw+J9d94E41LwT6ivKH0WT+fYwYWB0Zp3I3IZ7tI/BbUbrg==",
 			"dev": true,
 			"dependencies": {
-				"css-declaration-sorter": "^7.1.1",
-				"cssnano-utils": "^4.0.1",
+				"browserslist": "^4.23.0",
+				"css-declaration-sorter": "^7.2.0",
+				"cssnano-utils": "^4.0.2",
 				"postcss-calc": "^9.0.1",
-				"postcss-colormin": "^6.0.3",
-				"postcss-convert-values": "^6.0.4",
-				"postcss-discard-comments": "^6.0.1",
-				"postcss-discard-duplicates": "^6.0.2",
-				"postcss-discard-empty": "^6.0.2",
-				"postcss-discard-overridden": "^6.0.1",
-				"postcss-merge-longhand": "^6.0.3",
-				"postcss-merge-rules": "^6.0.4",
-				"postcss-minify-font-values": "^6.0.2",
-				"postcss-minify-gradients": "^6.0.2",
-				"postcss-minify-params": "^6.0.3",
-				"postcss-minify-selectors": "^6.0.2",
-				"postcss-normalize-charset": "^6.0.1",
-				"postcss-normalize-display-values": "^6.0.1",
-				"postcss-normalize-positions": "^6.0.1",
-				"postcss-normalize-repeat-style": "^6.0.1",
-				"postcss-normalize-string": "^6.0.1",
-				"postcss-normalize-timing-functions": "^6.0.1",
-				"postcss-normalize-unicode": "^6.0.3",
-				"postcss-normalize-url": "^6.0.1",
-				"postcss-normalize-whitespace": "^6.0.1",
-				"postcss-ordered-values": "^6.0.1",
-				"postcss-reduce-initial": "^6.0.3",
-				"postcss-reduce-transforms": "^6.0.1",
-				"postcss-svgo": "^6.0.2",
-				"postcss-unique-selectors": "^6.0.2"
+				"postcss-colormin": "^6.1.0",
+				"postcss-convert-values": "^6.1.0",
+				"postcss-discard-comments": "^6.0.2",
+				"postcss-discard-duplicates": "^6.0.3",
+				"postcss-discard-empty": "^6.0.3",
+				"postcss-discard-overridden": "^6.0.2",
+				"postcss-merge-longhand": "^6.0.5",
+				"postcss-merge-rules": "^6.1.1",
+				"postcss-minify-font-values": "^6.1.0",
+				"postcss-minify-gradients": "^6.0.3",
+				"postcss-minify-params": "^6.1.0",
+				"postcss-minify-selectors": "^6.0.4",
+				"postcss-normalize-charset": "^6.0.2",
+				"postcss-normalize-display-values": "^6.0.2",
+				"postcss-normalize-positions": "^6.0.2",
+				"postcss-normalize-repeat-style": "^6.0.2",
+				"postcss-normalize-string": "^6.0.2",
+				"postcss-normalize-timing-functions": "^6.0.2",
+				"postcss-normalize-unicode": "^6.1.0",
+				"postcss-normalize-url": "^6.0.2",
+				"postcss-normalize-whitespace": "^6.0.2",
+				"postcss-ordered-values": "^6.0.2",
+				"postcss-reduce-initial": "^6.1.0",
+				"postcss-reduce-transforms": "^6.0.2",
+				"postcss-svgo": "^6.0.3",
+				"postcss-unique-selectors": "^6.0.4"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -10782,9 +11198,9 @@
 			}
 		},
 		"node_modules/cssnano-utils": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.1.tgz",
-			"integrity": "sha512-6qQuYDqsGoiXssZ3zct6dcMxiqfT6epy7x4R0TQJadd4LWO3sPR6JH6ZByOvVLoZ6EdwPGgd7+DR1EmX3tiXQQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.2.tgz",
+			"integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==",
 			"dev": true,
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -11546,9 +11962,9 @@
 			}
 		},
 		"node_modules/envinfo": {
-			"version": "7.11.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.11.1.tgz",
-			"integrity": "sha512-8PiZgZNIB4q/Lw4AhOvAfB/ityHAd2bli3lESSWmWSzSsl5dKpy5N1d1Rfkd2teq/g9xN90lc6o98DOjMeYHpg==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
+			"integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
 			"dev": true,
 			"bin": {
 				"envinfo": "dist/cli.js"
@@ -12013,190 +12429,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
-			"dev": true,
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.62.0",
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/typescript-estree": "5.62.0",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/eslint-plugin-jest/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		},
 		"node_modules/eslint-plugin-jsdoc": {
 			"version": "46.10.1",
@@ -14170,9 +14402,9 @@
 			}
 		},
 		"node_modules/http-link-header": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.2.tgz",
-			"integrity": "sha512-6qz1XhMq/ryde52SZGzVhzi3jcG2KqO16KITkupyQxvW6u7iylm0Fq7r3OpCYsc0S0ELlCiFpuxDcccUwjbEqA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+			"integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -15873,9 +16105,9 @@
 			}
 		},
 		"node_modules/joi": {
-			"version": "17.12.2",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.12.2.tgz",
-			"integrity": "sha512-RonXAIzCiHLc8ss3Ibuz45u28GOsWE1UpfDXLbN/9NKbL4tCJf8TWYVKsoYuuh+sAUt7fsSNpA+r2+TBA6Wjmw==",
+			"version": "17.13.0",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.0.tgz",
+			"integrity": "sha512-9qcrTyoBmFZRNHeVP4edKqIUEgFzq7MHvTNSDuHSqkpOPtiBkgNgcmTSqmiw1kw9tdKaiddvIDv/eCJDxmqWCA==",
 			"dev": true,
 			"dependencies": {
 				"@hapi/hoek": "^9.3.0",
@@ -17152,9 +17384,9 @@
 			"dev": true
 		},
 		"node_modules/media-chrome": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-2.2.5.tgz",
-			"integrity": "sha512-59peAYFlL9ZlFVkKJmIgIDNMkQr4nauYTwIQhLg3khmGfO6/25VNEI8Yn0aUMLb5IFB2gzjcPmfu1ktfOhQ8Ag=="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-3.2.1.tgz",
+			"integrity": "sha512-WXWccoeu9bzMsPtTaEd340gzL/amE6LW0o13Dg0RSAwjNhFmuMmsBvRfO7m/GzMYjmOD4R/3Ckvte6jvHAK+mw=="
 		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
@@ -17291,6 +17523,15 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/micromodal": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
+			"integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/mime": {
@@ -17621,6 +17862,14 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
@@ -18319,9 +18568,9 @@
 			}
 		},
 		"node_modules/pac-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4"
@@ -18681,13 +18930,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-			"integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+			"version": "1.43.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
+			"integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.41.2"
+				"playwright-core": "1.43.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -18700,10 +18949,11 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-			"integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+			"version": "1.43.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
+			"integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -18724,19 +18974,6 @@
 			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/playwright/node_modules/playwright-core": {
-			"version": "1.41.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-			"integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
-			"dev": true,
-			"peer": true,
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/plur": {
@@ -18808,9 +19045,9 @@
 			}
 		},
 		"node_modules/postcss-colormin": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.3.tgz",
-			"integrity": "sha512-ECpkS+UZRyAtu/kjive2/1mihP+GNtgC8kcdU8ueWZi1ZVxMNnRziCLdhrWECJhEtSWijfX2Cl9XTTCK/hjGaA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.1.0.tgz",
+			"integrity": "sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0",
@@ -18826,9 +19063,9 @@
 			}
 		},
 		"node_modules/postcss-convert-values": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.4.tgz",
-			"integrity": "sha512-YT2yrGzPXoQD3YeA2kBo/696qNwn7vI+15AOS2puXWEvSWqdCqlOyDWRy5GNnOc9ACRGOkuQ4ESQEqPJBWt/GA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.1.0.tgz",
+			"integrity": "sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0",
@@ -18842,9 +19079,9 @@
 			}
 		},
 		"node_modules/postcss-discard-comments": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.1.tgz",
-			"integrity": "sha512-f1KYNPtqYLUeZGCHQPKzzFtsHaRuECe6jLakf/RjSRqvF5XHLZnM2+fXLhb8Qh/HBFHs3M4cSLb1k3B899RYIg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.2.tgz",
+			"integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==",
 			"dev": true,
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -18854,9 +19091,9 @@
 			}
 		},
 		"node_modules/postcss-discard-duplicates": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.2.tgz",
-			"integrity": "sha512-U2rsj4w6pAGROCCcD13LP2eBIi1whUsXs4kgE6xkIuGfkbxCBSKhkCTWyowFd66WdVlLv0uM1euJKIgmdmZObg==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
+			"integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
 			"dev": true,
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -18866,9 +19103,9 @@
 			}
 		},
 		"node_modules/postcss-discard-empty": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.2.tgz",
-			"integrity": "sha512-rj6pVC2dVCJrP0Y2RkYTQEbYaCf4HEm+R/2StQgJqGHxAa3+KcYslNQhcRqjLHtl/4wpzipJluaJLqBj6d5eDQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.3.tgz",
+			"integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==",
 			"dev": true,
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -18878,9 +19115,9 @@
 			}
 		},
 		"node_modules/postcss-discard-overridden": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.1.tgz",
-			"integrity": "sha512-qs0ehZMMZpSESbRkw1+inkf51kak6OOzNRaoLd/U7Fatp0aN2HQ1rxGOrJvYcRAN9VpX8kUF13R2ofn8OlvFVA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.2.tgz",
+			"integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==",
 			"dev": true,
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -18976,13 +19213,13 @@
 			"dev": true
 		},
 		"node_modules/postcss-merge-longhand": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.3.tgz",
-			"integrity": "sha512-kF/y3DU8CRt+SX3tP/aG+2gkZI2Z7OXDsPU7FgxIJmuyhQQ1EHceIYcsp/alvzCm2P4c37Sfdu8nNrHc+YeyLg==",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.5.tgz",
+			"integrity": "sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
-				"stylehacks": "^6.0.3"
+				"stylehacks": "^6.1.1"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -18992,15 +19229,15 @@
 			}
 		},
 		"node_modules/postcss-merge-rules": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.4.tgz",
-			"integrity": "sha512-97iF3UJ5v8N1BWy38y+0l+Z8o5/9uGlEgtWic2PJPzoRrLB6Gxg8TVG93O0EK52jcLeMsywre26AUlX1YAYeHA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.1.1.tgz",
+			"integrity": "sha512-KOdWF0gju31AQPZiD+2Ar9Qjowz1LTChSjFFbS+e2sFgc4uHOp3ZvVX4sNeTlk0w2O31ecFGgrFzhO0RSWbWwQ==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0",
 				"caniuse-api": "^3.0.0",
-				"cssnano-utils": "^4.0.1",
-				"postcss-selector-parser": "^6.0.15"
+				"cssnano-utils": "^4.0.2",
+				"postcss-selector-parser": "^6.0.16"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -19010,9 +19247,9 @@
 			}
 		},
 		"node_modules/postcss-minify-font-values": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.2.tgz",
-			"integrity": "sha512-IedzbVMoX0a7VZWjSYr5qJ6C37rws8kl8diPBeMZLJfWKkgXuMFY5R/OxPegn/q9tK9ztd0XRH3aR0u2t+A7uQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.1.0.tgz",
+			"integrity": "sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19025,13 +19262,13 @@
 			}
 		},
 		"node_modules/postcss-minify-gradients": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.2.tgz",
-			"integrity": "sha512-vP5mF7iI6/5fcpv+rSfwWQekOE+8I1i7/7RjZPGuIjj6eUaZVeG4XZYZrroFuw1WQd51u2V32wyQFZ+oYdE7CA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.3.tgz",
+			"integrity": "sha512-4KXAHrYlzF0Rr7uc4VrfwDJ2ajrtNEpNEuLxFgwkhFZ56/7gaE4Nr49nLsQDZyUe+ds+kEhf+YAUolJiYXF8+Q==",
 			"dev": true,
 			"dependencies": {
 				"colord": "^2.9.3",
-				"cssnano-utils": "^4.0.1",
+				"cssnano-utils": "^4.0.2",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -19042,13 +19279,13 @@
 			}
 		},
 		"node_modules/postcss-minify-params": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.3.tgz",
-			"integrity": "sha512-j4S74d3AAeCK5eGdQndXSrkxusV2ekOxbXGnlnZthMyZBBvSDiU34CihTASbJxuVB3bugudmwolS7+Dgs5OyOQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.1.0.tgz",
+			"integrity": "sha512-bmSKnDtyyE8ujHQK0RQJDIKhQ20Jq1LYiez54WiaOoBtcSuflfK3Nm596LvbtlFcpipMjgClQGyGr7GAs+H1uA==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0",
-				"cssnano-utils": "^4.0.1",
+				"cssnano-utils": "^4.0.2",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -19059,12 +19296,12 @@
 			}
 		},
 		"node_modules/postcss-minify-selectors": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.2.tgz",
-			"integrity": "sha512-0b+m+w7OAvZejPQdN2GjsXLv5o0jqYHX3aoV0e7RBKPCsB7TYG5KKWBFhGnB/iP3213Ts8c5H4wLPLMm7z28Sg==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.4.tgz",
+			"integrity": "sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==",
 			"dev": true,
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.15"
+				"postcss-selector-parser": "^6.0.16"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -19133,9 +19370,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-charset": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.1.tgz",
-			"integrity": "sha512-aW5LbMNRZ+oDV57PF9K+WI1Z8MPnF+A8qbajg/T8PP126YrGX1f9IQx21GI2OlGz7XFJi/fNi0GTbY948XJtXg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.2.tgz",
+			"integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==",
 			"dev": true,
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -19145,9 +19382,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-display-values": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.1.tgz",
-			"integrity": "sha512-mc3vxp2bEuCb4LgCcmG1y6lKJu1Co8T+rKHrcbShJwUmKJiEl761qb/QQCfFwlrvSeET3jksolCR/RZuMURudw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.2.tgz",
+			"integrity": "sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19160,9 +19397,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-positions": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.1.tgz",
-			"integrity": "sha512-HRsq8u/0unKNvm0cvwxcOUEcakFXqZ41fv3FOdPn916XFUrympjr+03oaLkuZENz3HE9RrQE9yU0Xv43ThWjQg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.2.tgz",
+			"integrity": "sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19175,9 +19412,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-repeat-style": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.1.tgz",
-			"integrity": "sha512-Gbb2nmCy6tTiA7Sh2MBs3fj9W8swonk6lw+dFFeQT68B0Pzwp1kvisJQkdV6rbbMSd9brMlS8I8ts52tAGWmGQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.2.tgz",
+			"integrity": "sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19190,9 +19427,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-string": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.1.tgz",
-			"integrity": "sha512-5Fhx/+xzALJD9EI26Aq23hXwmv97Zfy2VFrt5PLT8lAhnBIZvmaT5pQk+NuJ/GWj/QWaKSKbnoKDGLbV6qnhXg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.2.tgz",
+			"integrity": "sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19205,9 +19442,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-timing-functions": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.1.tgz",
-			"integrity": "sha512-4zcczzHqmCU7L5dqTB9rzeqPWRMc0K2HoR+Bfl+FSMbqGBUcP5LRfgcH4BdRtLuzVQK1/FHdFoGT3F7rkEnY+g==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.2.tgz",
+			"integrity": "sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19220,9 +19457,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-unicode": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.3.tgz",
-			"integrity": "sha512-T2Bb3gXz0ASgc3ori2dzjv6j/P2IantreaC6fT8tWjqYUiqMAh5jGIkdPwEV2FaucjQlCLeFJDJh2BeSugE1ig==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.1.0.tgz",
+			"integrity": "sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0",
@@ -19236,9 +19473,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-url": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.1.tgz",
-			"integrity": "sha512-jEXL15tXSvbjm0yzUV7FBiEXwhIa9H88JOXDGQzmcWoB4mSjZIsmtto066s2iW9FYuIrIF4k04HA2BKAOpbsaQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.2.tgz",
+			"integrity": "sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19251,9 +19488,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-whitespace": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.1.tgz",
-			"integrity": "sha512-76i3NpWf6bB8UHlVuLRxG4zW2YykF9CTEcq/9LGAiz2qBuX5cBStadkk0jSkg9a9TCIXbMQz7yzrygKoCW9JuA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.2.tgz",
+			"integrity": "sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19266,12 +19503,12 @@
 			}
 		},
 		"node_modules/postcss-ordered-values": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.1.tgz",
-			"integrity": "sha512-XXbb1O/MW9HdEhnBxitZpPFbIvDgbo9NK4c/5bOfiKpnIGZDoL2xd7/e6jW5DYLsWxBbs+1nZEnVgnjnlFViaA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.2.tgz",
+			"integrity": "sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==",
 			"dev": true,
 			"dependencies": {
-				"cssnano-utils": "^4.0.1",
+				"cssnano-utils": "^4.0.2",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -19291,9 +19528,9 @@
 			}
 		},
 		"node_modules/postcss-reduce-initial": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.3.tgz",
-			"integrity": "sha512-w4QIR9pEa1N4xMx3k30T1vLZl6udVK2RmNqrDXhBXX9L0mBj2a8ADs8zkbaEH7eUy1m30Wyr5EBgHN31Yq1JvA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
+			"integrity": "sha512-RarLgBK/CrL1qZags04oKbVbrrVK2wcxhvta3GCxrZO4zveibqbRPmm2VI8sSgCXwoUHEliRSbOfpR0b/VIoiw==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0",
@@ -19307,9 +19544,9 @@
 			}
 		},
 		"node_modules/postcss-reduce-transforms": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.1.tgz",
-			"integrity": "sha512-fUbV81OkUe75JM+VYO1gr/IoA2b/dRiH6HvMwhrIBSUrxq3jNZQZitSnugcTLDi1KkQh1eR/zi+iyxviUNBkcQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.2.tgz",
+			"integrity": "sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -19370,9 +19607,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.15",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
-			"integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
+			"version": "6.0.16",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+			"integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
 			"dev": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -19383,9 +19620,9 @@
 			}
 		},
 		"node_modules/postcss-svgo": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.2.tgz",
-			"integrity": "sha512-IH5R9SjkTkh0kfFOQDImyy1+mTCb+E830+9SV1O+AaDcoHTvfsvt6WwJeo7KwcHbFnevZVCsXhDmjFiGVuwqFQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.3.tgz",
+			"integrity": "sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
@@ -19399,12 +19636,12 @@
 			}
 		},
 		"node_modules/postcss-unique-selectors": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.2.tgz",
-			"integrity": "sha512-8IZGQ94nechdG7Y9Sh9FlIY2b4uS8/k8kdKRX040XHsS3B6d1HrJAkXrBSsSu4SuARruSsUjW3nlSw8BHkaAYQ==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.4.tgz",
+			"integrity": "sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==",
 			"dev": true,
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.15"
+				"postcss-selector-parser": "^6.0.16"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -19432,9 +19669,9 @@
 			"dev": true
 		},
 		"node_modules/preact": {
-			"version": "10.19.6",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.6.tgz",
-			"integrity": "sha512-gympg+T2Z1fG1unB8NH29yHJwnEaCH37Z32diPDku316OTnRPeMbiRV9kTrfZpocXjdfnWuFUl/Mj4BHaf6gnw==",
+			"version": "10.21.0",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.21.0.tgz",
+			"integrity": "sha512-aQAIxtzWEwH8ou+OovWVSVNlFImL7xUCwJX3YMqA3U8iKCNC34999fFOnWjYNsylgfPgMexpbk7WYOLtKr/mxg==",
 			"dev": true,
 			"funding": {
 				"type": "opencollective",
@@ -19625,9 +19862,9 @@
 			}
 		},
 		"node_modules/proxy-agent/node_modules/agent-base": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4"
@@ -19952,9 +20189,9 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -19988,15 +20225,15 @@
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
-				"scheduler": "^0.23.0"
+				"scheduler": "^0.23.2"
 			},
 			"peerDependencies": {
-				"react": "^18.2.0"
+				"react": "^18.3.1"
 			}
 		},
 		"node_modules/react-easy-crop": {
@@ -20257,62 +20494,6 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/reakit": {
-			"version": "1.3.11",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
-			"integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
-			"dev": true,
-			"dependencies": {
-				"@popperjs/core": "^2.5.4",
-				"body-scroll-lock": "^3.1.5",
-				"reakit-system": "^0.15.2",
-				"reakit-utils": "^0.15.2",
-				"reakit-warning": "^0.6.2"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ariakit"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0"
-			}
-		},
-		"node_modules/reakit/node_modules/reakit-system": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
-			"integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
-			"dev": true,
-			"dependencies": {
-				"reakit-utils": "^0.15.2"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0"
-			}
-		},
-		"node_modules/reakit/node_modules/reakit-utils": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-			"dev": true,
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0"
-			}
-		},
-		"node_modules/reakit/node_modules/reakit-warning": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
-			"integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
-			"dev": true,
-			"dependencies": {
-				"reakit-utils": "^0.15.2"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0"
 			}
 		},
 		"node_modules/rechoir": {
@@ -20846,9 +21027,9 @@
 			}
 		},
 		"node_modules/scheduler": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}
@@ -21619,9 +21800,9 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
-			"integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
 			"dev": true,
 			"dependencies": {
 				"ip-address": "^9.0.5",
@@ -21633,12 +21814,12 @@
 			}
 		},
 		"node_modules/socks-proxy-agent": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
-			"integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
+			"integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
 			"dev": true,
 			"dependencies": {
-				"agent-base": "^7.0.2",
+				"agent-base": "^7.1.1",
 				"debug": "^4.3.4",
 				"socks": "^2.7.1"
 			},
@@ -21647,9 +21828,9 @@
 			}
 		},
 		"node_modules/socks-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4"
@@ -22143,13 +22324,13 @@
 			"dev": true
 		},
 		"node_modules/stylehacks": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.3.tgz",
-			"integrity": "sha512-KzBqjnqktc8/I0ERCb+lGq06giF/JxDbw2r9kEVhen9noHeIDRtMWUp9r62sOk+/2bbX6sFG1GhsS7ToXG0PEg==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
+			"integrity": "sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0",
-				"postcss-selector-parser": "^6.0.15"
+				"postcss-selector-parser": "^6.0.16"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -22942,9 +23123,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
-			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=16"
@@ -23159,9 +23340,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -23392,12 +23573,12 @@
 			}
 		},
 		"node_modules/use-lilius": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.4.tgz",
-			"integrity": "sha512-5y4yKCDivylrUOB5V19BKLWFVyjInC/nkOHjiy4M5qjZzRR0HJQtNKVOZ+o5SMW+mOj1wIg65qXZ0uJF40Iv4w==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.5.tgz",
+			"integrity": "sha512-IbPjJe4T6B0zQV6ahftVtHvCAxi6RAuDpEcO8TmnHh4nBtx7JbGdpbgXWOUj/9YjrzEbdT/lW7JWcBVbX3MbrA==",
 			"dev": true,
 			"dependencies": {
-				"date-fns": "^3.0.0"
+				"date-fns": "^3.6.0"
 			},
 			"peerDependencies": {
 				"react": "*",
@@ -23405,9 +23586,9 @@
 			}
 		},
 		"node_modules/use-lilius/node_modules/date-fns": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
-			"integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
 			"dev": true,
 			"funding": {
 				"type": "github",

--- a/package.json
+++ b/package.json
@@ -41,26 +41,26 @@
 		"prepare": "husky install"
 	},
 	"dependencies": {
-		"@wordpress/icons": "^9.43.0",
+		"@wordpress/icons": "^9.26.3",
 		"classnames": "^2.5.1",
-		"media-chrome": "^2.2.5"
+		"media-chrome": "^3.2.1"
 	},
 	"devDependencies": {
-		"@types/react": "^18.2.58",
-		"@types/react-dom": "^18.2.19",
-		"@types/wordpress__block-editor": "^11.5.10",
-		"@types/wordpress__blocks": "^12.5.13",
-		"@wordpress/block-editor": "^11.3.11",
-		"@wordpress/block-library": "^8.3.14",
-		"@wordpress/blocks": "^12.3.4",
-		"@wordpress/components": "^23.3.8",
-		"@wordpress/data": "^8.3.4",
-		"@wordpress/element": "^5.3.3",
-		"@wordpress/eslint-plugin": "^17.9.0",
-		"@wordpress/notices": "^3.26.4",
-		"@wordpress/prettier-config": "^3.9.0",
-		"@wordpress/scripts": "^27.3.0",
-		"@wordpress/stylelint-config": "^21.35.0",
+		"@types/react": "^18.3.1",
+		"@types/react-dom": "^18.3.0",
+		"@types/wordpress__block-editor": "^11.5.14",
+		"@types/wordpress__blocks": "^12.5.14",
+		"@wordpress/block-editor": "^12.3.15",
+		"@wordpress/block-library": "^8.12.19",
+		"@wordpress/blocks": "^12.12.8",
+		"@wordpress/components": "^25.1.12",
+		"@wordpress/data": "^9.5.6",
+		"@wordpress/element": "^5.12.2",
+		"@wordpress/eslint-plugin": "^17.13.0",
+		"@wordpress/notices": "^4.3.6",
+		"@wordpress/prettier-config": "^3.13.0",
+		"@wordpress/scripts": "^27.7.0",
+		"@wordpress/stylelint-config": "^21.39.0",
 		"@wp-blocks/make-pot": "^1.2.0",
 		"@wp-blocks/tsconfig": "^0.1.0",
 		"eslint": "^8.57.0",
@@ -69,9 +69,9 @@
 		"husky": "^9.0.11",
 		"lint-staged": "^15.2.2",
 		"prettier": "^3.2.5",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
 		"stylelint": "^14.16.1",
-		"typescript": "^5.3.3"
+		"typescript": "^5.4.5"
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Vinyl ===
 Contributors:      bitmachina, codekraft
 Tags:              audio, block, playlist, player, sound
-Requires at least: 6.2
-Tested up to:      6.4
+Requires at least: 6.3
+Tested up to:      6.5
 Requires PHP:      7.4
-Stable tag:        0.1.2
+Stable tag:        0.1.3
 License:           GPL v2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,7 +26,7 @@ improving the user experience.
 
 = Minimum Requirements =
 
-* WordPress 6.2 or greater
+* WordPress 6.3 or greater
 * PHP version 7.4 or greater
 
 == Source Code ==
@@ -37,6 +37,10 @@ This plugin is uses the library [media-chrome](https://github.com/muxinc/media-c
 the audio player.
 
 == Changelog ==
+
+= 0.1.3: April 30th, 2024 =
+* Update media-chrome library to version v3.
+* Update minimum WordPress version to 6.3.
 
 = 0.1.2: April 29th, 2024 =
 * Fix plugin review issues. Add source code link and update the readme.txt to match the plugin header.

--- a/src/audio/style.scss
+++ b/src/audio/style.scss
@@ -15,10 +15,15 @@
 	.vinyl__player {
 		width: 100%;
 		/* Prevent layout shift from before the media controls render. */
-		min-height: 44px;
+		min-height: 88px;
 		/* The browser natively applies a 300px width to the audio block. */
 		/* We restore this as a min-width instead, for alignments. */
 		min-width: 300px;
+
+		@media (min-width: 650px) {
+			/* Prevent layout shift from before the media controls render. */
+			min-height: 44px;
+		}
 	}
 
 	.vinyl__control-bar {

--- a/vinyl.php
+++ b/vinyl.php
@@ -3,8 +3,8 @@
  * Plugin Name:       Vinyl Audio
  * Plugin URI:        https://github.com/wp-blocks/vinyl
  * Description:       An advanced WordPress audio player.
- * Version:           0.1.2
- * Requires at least: 6.2
+ * Version:           0.1.3
+ * Requires at least: 6.3
  * Requires PHP:      7.4
  * Author:            codekraft, bitmachina
  * Author URI:        https://github.com/wp-blocks


### PR DESCRIPTION
- Update other dependencies.
- Bump the minimum supported WordPress version to 6.3 (2 behind the current version).
- @wordpress/* packages should target 6.3.
- Also increase the minimum height of the player on mobile to 88px.

Fixes #8