### PR TITLE
feat: add translated labels to the vinyl player

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,6 +46,12 @@ module.exports = {
 		],
 
 		'jsdoc/require-param': 'off',
+		'jsdoc/check-tag-names': [
+			'error',
+			{
+				definedTags: ['attr', 'csspart', 'cssproperty', 'slot'],
+			},
+		],
 
 		// Enable these once Gutenberg types are figured out.
 		'@typescript-eslint/no-unsafe-argument': 'off',
@@ -94,5 +100,8 @@ module.exports = {
 		browser: true,
 		es2017: true,
 		node: true,
+	},
+	globals: {
+		globalThis: 'writable',
 	},
 };

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The goal of this block is to create a customizable audio player that builds on t
 
 -   [x] Replicate the functionality of `core/audio`.
 -   [x] Provide transforms to and from `core/audio`.
+-   [x] Fully translatable
 -   [ ] Accessible UI
 -   [ ] Customizable UI
 -   [ ] Playlists

--- a/bin/react/build.js
+++ b/bin/react/build.js
@@ -1,0 +1,322 @@
+/* eslint-disable no-console */
+
+/**
+ * This file is a modified version of the `scripts/react/builds.js` file from
+ * the `media-chrome` package.
+ *
+ * The original file can be found at the following link:
+ *
+ * https://github.com/muxinc/media-chrome/blob/692be61a2a63ba98c7e449d860ce1828b78353a2/scripts/react/build.js
+ */
+
+/**
+ * Copyright (c) 2020 Mux, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Notes about the current implementation of the React wrapper compiler:
+// Currently relies on a build having already been generated.
+// Outputs (uncompiled) ES Modules to the dist dir
+// Does not currently support "extras" components
+
+// REACT MODULE STRING CREATION CODE BEGIN
+const clearAndUpper = (kebabText) => {
+	return kebabText.replace(/-/, '').toUpperCase();
+};
+
+const toPascalCase = (kebabText) => {
+	return kebabText.replace(/(^\w|-\w)/g, clearAndUpper);
+};
+
+const toImportsStr = ({ importPath }) => {
+	return `/* eslint-disable */
+// @ts-nocheck
+
+import React from "react";
+import "${importPath}";
+import { toNativeProps } from "./common/utils.js";
+`;
+};
+
+const toReactComponentStr = (config) => {
+	const { elementName } = config;
+	const ReactComponentName = toPascalCase(elementName);
+	return `/** @type { import("react").HTMLElement } */
+const ${ReactComponentName} = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('${elementName}', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});`;
+};
+
+const toExportsStr = (config) => {
+	const { elementName } = config;
+	const ReactComponentName = toPascalCase(elementName);
+	return `export { ${ReactComponentName} };`;
+};
+
+const toCustomElementReactWrapperModule = (config) => {
+	const moduleStr = `${toReactComponentStr(config)}
+
+${toExportsStr(config)}
+`;
+
+	return moduleStr;
+};
+// REACT MODULE STRING CREATION CODE END
+
+// TYPESCRIPT DECLARATION FILE STRING CREATION CODE BEGIN
+const toTypeImportsAndGenericDefinitionsStr = () => {
+	return `/* eslint-disable */
+// @ts-nocheck
+
+import type React from 'react';
+
+import type * as CSS from 'csstype';
+declare global {
+  interface Element {
+    slot?: string;
+  }
+}
+
+declare module 'csstype' {
+  interface Properties {
+    // Should add generic support for any CSS variables
+    [index: \`--\${string}\`]: any;
+  }
+}
+
+type GenericProps = { [k: string]: any };
+type GenericElement = HTMLElement;
+
+type GenericForwardRef = React.ForwardRefExoticComponent<
+  GenericProps & React.RefAttributes<GenericElement | undefined>
+>;
+`;
+};
+
+const toDeclarationStr = (config) => {
+	const { elementName } = config;
+	const ReactComponentName = toPascalCase(elementName);
+	return `declare const ${ReactComponentName}: GenericForwardRef;`;
+};
+
+const toCustomElementReactTypeDeclaration = (config) => {
+	const typeDeclarationStr = `${toDeclarationStr(config)}
+${toExportsStr(config)}
+`;
+
+	return typeDeclarationStr;
+};
+// TYPESCRIPT DECLARATION FILE STRING CREATION CODE END
+
+// BUILD BEGIN
+
+const entryPointsToReactModulesIterable = (
+	entryPoints,
+	{ getDefinedCustomElements, distRoot }
+) => {
+	let alreadyDefinedCustomElementNames = [];
+	return {
+		[Symbol.asyncIterator]() {
+			return {
+				i: 0,
+				next() {
+					const { i } = this;
+					if (i >= entryPoints.length)
+						return Promise.resolve({ done: true });
+
+					const importPath = entryPoints[i];
+					const importPathAbs = require.resolve(importPath);
+					const importPathObj = path.parse(importPathAbs);
+					// Remove `-element` suffix for React modules
+					const name = importPathObj.name.replace(/-element$/, '');
+					const modulePathAbs = path.format({
+						dir: distRoot,
+						name,
+						ext: '.js',
+					});
+					const tsDeclPathAbs = path.format({
+						dir: distRoot,
+						name,
+						ext: '.d.ts',
+					});
+
+					const importPathRelative = path.relative(
+						distRoot,
+						importPathAbs
+					);
+					return import(importPath)
+						.then((_) => {
+							const customElementNames =
+								getDefinedCustomElements().filter(
+									(customElementName) =>
+										customElementName.startsWith('vinyl-')
+								);
+
+							const undefinedCustomElementNames =
+								customElementNames.filter(
+									/* eslint-disable-next-line no-shadow */
+									(name) =>
+										!alreadyDefinedCustomElementNames.includes(
+											name
+										)
+								);
+
+							const componentsWithExports =
+								undefinedCustomElementNames.map(
+									(elementName) => {
+										return toCustomElementReactWrapperModule(
+											{
+												elementName,
+											}
+										);
+									}
+								);
+
+							const moduleStr = `${toImportsStr({
+								importPath: importPathRelative,
+							})}\n${componentsWithExports.join('\n')}`;
+
+							fs.writeFileSync(modulePathAbs, moduleStr);
+
+							const declarationsWithExports =
+								undefinedCustomElementNames.map(
+									(elementName) => {
+										return toCustomElementReactTypeDeclaration(
+											{ elementName }
+										);
+									}
+								);
+
+							const tsDeclStr = `${toTypeImportsAndGenericDefinitionsStr()}\n${declarationsWithExports.join(
+								'\n'
+							)}`;
+
+							fs.writeFileSync(tsDeclPathAbs, tsDeclStr);
+
+							alreadyDefinedCustomElementNames = [
+								...customElementNames,
+							];
+
+							return {
+								modulePath: modulePathAbs,
+								moduleContents: moduleStr,
+								tsDeclarationPath: tsDeclPathAbs,
+								tsDeclarationContents: tsDeclStr,
+							};
+						})
+						.then((moduleDef) => {
+							this.i++;
+							return { value: moduleDef, done: false };
+						})
+						.catch((err) => {
+							return Promise.reject({ value: err });
+						});
+				},
+			};
+		},
+	};
+};
+
+const createReactWrapperModules = ({
+	entryPoints,
+	setupGlobalsAsync,
+	distRoot = './',
+	commonModulesSrcRoot = path.join(__dirname, 'common'),
+}) => {
+	return setupGlobalsAsync().then(async (customElementNames) => {
+		if (!entryPoints?.length) {
+			console.error('no entrypoints! bailing');
+			return;
+		}
+
+		fs.mkdirSync(distRoot, { recursive: true });
+
+		const commonModulesDistPath = path.join(distRoot, 'common');
+		fs.mkdirSync(commonModulesDistPath, { recursive: true });
+		fs.readdirSync(commonModulesSrcRoot, { withFileTypes: true }).forEach(
+			(dirEntryObj) => {
+				const { name } = dirEntryObj;
+				fs.copyFileSync(
+					path.format({ name, dir: commonModulesSrcRoot }),
+					path.format({ name, dir: commonModulesDistPath })
+				);
+			}
+		);
+
+		const moduleCreateAsyncIterable = entryPointsToReactModulesIterable(
+			entryPoints,
+			{ getDefinedCustomElements: () => customElementNames, distRoot }
+		);
+
+		try {
+			for await (const moduleDef of moduleCreateAsyncIterable) {
+				const { modulePath, moduleContents } = moduleDef;
+				console.log(
+					'React module wrapper created!',
+					'path (absolute):',
+					modulePath
+					// '\n',
+					// 'contents:',
+					// moduleContents
+				);
+			}
+		} catch (err) {
+			console.log('unexpected error generating module!', err);
+		}
+
+		console.log('module generation completed!');
+	});
+};
+
+export { toCustomElementReactWrapperModule };
+// BUILD END
+
+// EXTERNALIZEABLE/CONFIG CODE BEGIN
+const projectRoot = path.join(__dirname, '..', '..');
+const distRoot = path.join(projectRoot, 'src', 'react');
+const entryPoints = [
+	path.join(projectRoot, 'src', 'web-components', 'index.js'),
+];
+const setupGlobalsAsync = async () => {
+	const customElementNames = await import(
+		path.join(projectRoot, 'src', 'utils', 'server-safe-globals.js')
+	).then((exports) => {
+		Object.assign(globalThis, exports.globalThis);
+		globalThis.customElementNames = [];
+		globalThis.customElements.define = (name, _classRef) =>
+			globalThis.customElementNames.push(name);
+		// NOTE: The current implementation relies on the fact that `customElementNames` will be mutated
+		// to add the Custom Element html name for every element that's defined as a result of loading/importing the entryPoints modules (CJP).
+		return globalThis.customElementNames;
+	});
+	return customElementNames;
+};
+
+createReactWrapperModules({ entryPoints, setupGlobalsAsync, distRoot });
+// EXTERNALIZEABLE/CONFIG CODE END

--- a/bin/react/common/utils.js
+++ b/bin/react/common/utils.js
@@ -1,0 +1,74 @@
+/* eslint-disable */
+// @ts-nocheck
+
+/**
+ * This file is a modified version of the `scripts/react/common/utils.js` file
+ * from the `media-chrome` package.
+ *
+ * The original file can be found at the following link:
+ *
+ * https://github.com/muxinc/media-chrome/blob/692be61a2a63ba98c7e449d860ce1828b78353a2/scripts/react/common/utils.js
+ */
+
+/**
+ * Copyright (c) 2020 Mux, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const ReactPropToAttrNameMap = {
+	className: 'class',
+	classname: 'class',
+	htmlFor: 'for',
+	crossOrigin: 'crossorigin',
+	viewBox: 'viewBox',
+};
+
+export const toNativeAttrName = (propName, propValue) => {
+	if (ReactPropToAttrNameMap[propName])
+		return ReactPropToAttrNameMap[propName];
+	if (typeof propValue === undefined) return undefined;
+	if (typeof propValue === 'boolean' && !propValue) return undefined;
+	if (/[A-Z]/.test(propName)) return propName.toLowerCase();
+	return propName;
+};
+
+export const toNativeAttrValue = (propValue, _propName) => {
+	if (typeof propValue === 'boolean') return '';
+	if (Array.isArray(propValue)) return propValue.join(' ');
+	return propValue;
+};
+
+export const toNativeProps = (props = {}) => {
+	return Object.entries(props).reduce(
+		(transformedProps, [propName, propValue]) => {
+			const attrName = toNativeAttrName(propName, propValue);
+
+			// prop was stripped. Don't add.
+			if (!attrName) {
+				return transformedProps;
+			}
+
+			const attrValue = toNativeAttrValue(propValue, propName);
+			transformedProps[attrName] = attrValue;
+			return transformedProps;
+		},
+		{}
+	);
+};

--- a/languages/vinyl.pot
+++ b/languages/vinyl.pot
@@ -1,18 +1,18 @@
 # Copyright (C) 2024 vinyl
-# This file is distributed under the GPL       v2 or later license.
+# This file is distributed under the GPL v2 or later license.
 msgid ""
 msgstr ""
-"Project-Id-Version: vinyl 0.1.1\n"
+"Project-Id-Version: vinyl 0.1.3\n"
 "Report-Msgid-Bugs-To: codekraft, bitmachina <EMAIL>\n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
-"POT-Creation-Date: 2024-03-23T14:21:53.105Z\n"
+"POT-Creation-Date: 2024-05-27T14:00:03.421Z\n"
 "PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
 "Last-Translator: codekraft, bitmachina <EMAIL>\n"
 "Language-Team: codekraft, bitmachina <EMAIL>\n"
-"X-Generator: @wp-blocks/make-pot 1.2.0\n"
+"X-Generator: @wp-blocks/make-pot 1.3.2\n"
 "Language: en\n"
 "domain: X-Domain: vinyl\n"
 
@@ -47,7 +47,156 @@ msgid "Vinyl Audio requires PHP 7.4 or higher."
 msgstr ""
 
 #: vinyl.php:41
-msgid "Vinyl Audio requires WordPress 6.2 or later."
+msgid "Vinyl Audio requires WordPress 6.3 or later."
+msgstr ""
+
+#: src/web-components/vinyl-time-display.js:41
+msgid "Media not loaded, unknown time."
+msgstr ""
+
+# 1: current time, 2: total time
+#: src/web-components/vinyl-time-display.js:77
+msgid "%1$s of %2$s"
+msgstr ""
+
+# playback rate with multiplication symbol
+#: src/web-components/vinyl-playback-rate-button.js:58
+#: src/web-components/vinyl-playback-rate-button.js:76
+msgid "%sx"
+msgstr ""
+
+#: src/utils/time.js:37
+msgid "hour"
+msgstr ""
+
+#: src/utils/time.js:38
+msgid "hours"
+msgstr ""
+
+#: src/utils/time.js:41
+msgid "minute"
+msgstr ""
+
+#: src/utils/time.js:42
+msgid "minutes"
+msgstr ""
+
+#: src/utils/time.js:45
+msgid "second"
+msgstr ""
+
+#: src/utils/time.js:46
+msgid "seconds"
+msgstr ""
+
+#: src/labels/create-labels.js:5
+msgid "audio player"
+msgstr ""
+
+#: src/labels/create-labels.js:6
+msgid "video player"
+msgstr ""
+
+#: src/labels/create-labels.js:7
+msgid "volume"
+msgstr ""
+
+#: src/labels/create-labels.js:8
+msgid "seek"
+msgstr ""
+
+#: src/labels/create-labels.js:9
+msgid "closed captions"
+msgstr ""
+
+#: src/labels/create-labels.js:13
+msgid "playback time"
+msgstr ""
+
+#: src/labels/create-labels.js:14
+msgid "media loading"
+msgstr ""
+
+#: src/labels/create-labels.js:15
+msgid "settings"
+msgstr ""
+
+#: src/labels/create-labels.js:16
+msgid "audio tracks"
+msgstr ""
+
+#: src/labels/create-labels.js:17
+msgid "quality"
+msgstr ""
+
+#: src/labels/create-labels.js:21
+msgid "play"
+msgstr ""
+
+#: src/labels/create-labels.js:22
+msgid "pause"
+msgstr ""
+
+#: src/labels/create-labels.js:23
+msgid "mute"
+msgstr ""
+
+#: src/labels/create-labels.js:24
+msgid "unmute"
+msgstr ""
+
+#: src/labels/create-labels.js:25
+msgid "start airplay"
+msgstr ""
+
+#: src/labels/create-labels.js:26
+msgid "stop airplay"
+msgstr ""
+
+#: src/labels/create-labels.js:27
+msgid "start casting"
+msgstr ""
+
+#: src/labels/create-labels.js:28
+msgid "stop casting"
+msgstr ""
+
+#: src/labels/create-labels.js:29
+msgid "enter fullscreen mode"
+msgstr ""
+
+#: src/labels/create-labels.js:30
+msgid "exit fullscreen mode"
+msgstr ""
+
+#: src/labels/create-labels.js:31
+msgid "enter picture in picture mode"
+msgstr ""
+
+#: src/labels/create-labels.js:32
+msgid "exit picture in picture mode"
+msgstr ""
+
+# number of seconds to seek forward.
+#: src/labels/create-labels.js:36
+msgid "seek forward %s second"
+msgid_plural "seek forward %s seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+# number of seconds to seek backward.
+#: src/labels/create-labels.js:47
+msgid "seek back %s second"
+msgid_plural "seek back %s seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/labels/create-labels.js:55
+msgid "seek to live"
+msgstr ""
+
+#: src/labels/create-labels.js:56
+msgid "playing live"
 msgstr ""
 
 #: src/audio/edit.tsx:152
@@ -72,21 +221,6 @@ msgstr ""
 
 #: src/audio/edit.tsx:209
 msgid "Audio caption text"
-msgstr ""
-
-#: block.json
-#. title
-msgid "title"
-msgstr ""
-
-#: block.json
-#. description
-msgid "description"
-msgstr ""
-
-#: block.json
-#. keywords
-msgid "keywords"
 msgstr ""
 
 #: src/audio/edit/caption.tsx:28

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@wordpress/prettier-config": "^3.13.0",
 				"@wordpress/scripts": "^27.7.0",
 				"@wordpress/stylelint-config": "^21.39.0",
-				"@wp-blocks/make-pot": "^1.2.0",
+				"@wp-blocks/make-pot": "^1.3.2",
 				"@wp-blocks/tsconfig": "^0.1.0",
 				"eslint": "^8.57.0",
 				"eslint-import-resolver-typescript": "^3.6.1",
@@ -8744,25 +8744,28 @@
 			}
 		},
 		"node_modules/@wp-blocks/make-pot": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wp-blocks/make-pot/-/make-pot-1.2.0.tgz",
-			"integrity": "sha512-2lPRDabAWWHH1fX2w6kc1OWH8GLjEs10YyuryEF8fVFulMOtJ3fzL0z/EhSsoN7LRhYaDSHgW3mHDBNv3AC40w==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@wp-blocks/make-pot/-/make-pot-1.3.2.tgz",
+			"integrity": "sha512-QiqMsjkUbP2FWrtvbNI2UcXEy2KXwfzj/u87HHRCELwfx4Jz07+EdzX2Q+IZJAzi006b9ZMq7KrWfy1xr+OL6Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"axios": "^1.6.8",
+				"axios": "^1.7.2",
 				"cli-progress": "^3.12.0",
 				"gettext-merger": "^1.2.1",
-				"gettext-parser": "^7.0.1",
+				"gettext-parser": "^4.0.4",
 				"glob": "^10.3.10",
 				"tree-sitter": "^0.20.6",
 				"tree-sitter-javascript": "^0.20.4",
 				"tree-sitter-php": "^0.20.0",
 				"tree-sitter-typescript": "^0.20.5",
-				"yargs": "^17.7.2"
+				"yargs": "^17.7.1"
 			},
 			"bin": {
 				"make-pot": "lib/index.js"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@wp-blocks/make-pot/node_modules/brace-expansion": {
@@ -8774,39 +8777,15 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/@wp-blocks/make-pot/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
 		"node_modules/@wp-blocks/make-pot/node_modules/gettext-parser": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-7.0.1.tgz",
-			"integrity": "sha512-LU+ieGH3L9HmKEArTlX816/iiAlyA0fx/n/QSeQpkAaH/+jxMk/5UtDkAzcVvW+KlY25/U+IE6dnfkJ8ynt8pQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-4.2.0.tgz",
+			"integrity": "sha512-aMgPyjC9W5Mz9tbFU8DcQ7GYMXoFWq633kaWGt4imlcpBWzDIWk7HY7nCSZTCJxyjRaLq9L/NEjMKkZ9gR630Q==",
 			"dev": true,
 			"dependencies": {
-				"content-type": "^1.0.5",
+				"content-type": "^1.0.4",
 				"encoding": "^0.1.13",
-				"readable-stream": "^4.3.0",
+				"readable-stream": "^3.6.0",
 				"safe-buffer": "^5.2.1"
 			}
 		},
@@ -8847,22 +8826,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@wp-blocks/make-pot/node_modules/readable-stream": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-			"integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-			"dev": true,
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
 		"node_modules/@wp-blocks/tsconfig": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@wp-blocks/tsconfig/-/tsconfig-0.1.0.tgz",
@@ -8891,18 +8854,6 @@
 			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
 			"deprecated": "Use your platform's native atob() and btoa() methods instead",
 			"dev": true
-		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
-			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
-			}
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -9477,9 +9428,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.6.8",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-			"integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+			"integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
 			"dev": true,
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
@@ -12853,15 +12804,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/eventemitter3": {
@@ -19764,15 +19706,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/wp-blocks/vinyl/issues"
 	},
+	"type": "module",
 	"files": [
 		"build/*",
 		"includes/*",
@@ -30,6 +31,7 @@
 	"scripts": {
 		"build": "wp-scripts build --config webpack.config.cjs",
 		"build:pot": "make-pot . languages",
+		"build:react": "node ./bin/react/build.js",
 		"clean": "rm -rf build",
 		"format": "wp-scripts format",
 		"lint:css": "wp-scripts lint-style",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@wordpress/prettier-config": "^3.13.0",
 		"@wordpress/scripts": "^27.7.0",
 		"@wordpress/stylelint-config": "^21.39.0",
-		"@wp-blocks/make-pot": "^1.2.0",
+		"@wp-blocks/make-pot": "^1.3.2",
 		"@wp-blocks/tsconfig": "^0.1.0",
 		"eslint": "^8.57.0",
 		"eslint-import-resolver-typescript": "^3.6.1",

--- a/src/audio/edit.tsx
+++ b/src/audio/edit.tsx
@@ -25,8 +25,8 @@ import classnames from 'classnames';
 
 import './editor.scss';
 
-import Caption from './edit/caption';
-import { Player } from './player/index';
+import Caption from './edit/caption.js';
+import { Player } from './player/index.js';
 import type { Attributes } from './types';
 
 const ALLOWED_MEDIA_TYPES = ['audio'];

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -5,9 +5,9 @@ import { audio as icon } from '@wordpress/icons';
 import './style.scss';
 
 import metadata from './block.json';
-import edit from './edit';
-import save from './save';
-import transforms from './transforms';
+import edit from './edit.js';
+import save from './save.js';
+import transforms from './transforms.js';
 import type { Attributes } from './types';
 
 /**

--- a/src/audio/media-chrome.js
+++ b/src/audio/media-chrome.js
@@ -1,1 +1,0 @@
-import 'media-chrome';

--- a/src/audio/player/index.ts
+++ b/src/audio/player/index.ts
@@ -1,1 +1,1 @@
-export { default as Player } from './player';
+export { default as Player } from './player.js';

--- a/src/audio/player/player.tsx
+++ b/src/audio/player/player.tsx
@@ -1,40 +1,39 @@
 import {
-	MediaPlaybackRateButton,
-	MediaController,
-	MediaControlBar,
-	MediaTimeRange,
-	MediaTimeDisplay,
-	MediaVolumeRange,
-	MediaPlayButton,
-	MediaSeekBackwardButton,
-	MediaSeekForwardButton,
-	MediaMuteButton,
-} from 'media-chrome/dist/react';
-
-import { Attributes } from '../types';
+	VinylController,
+	VinylControlBar,
+	VinylMuteButton,
+	VinylPlayButton,
+	VinylPlaybackRateButton,
+	VinylSeekBackwardButton,
+	VinylSeekForwardButton,
+	VinylTimeRange,
+	VinylTimeDisplay,
+	VinylVolumeRange,
+} from '../../react/index.js';
+import type { Attributes } from '../types';
 
 type Props = Omit<Attributes, 'caption' | 'id'>;
 
 export default function Player({ loop, preload, src }: Props) {
 	return (
-		<MediaController audio={true} autohide="-1" className="vinyl__player">
+		<VinylController audio={true} autohide="-1" className="vinyl__player">
 			<audio slot="media" src={src} preload={preload} loop={loop} />
-			<MediaControlBar className="vinyl__control-bar">
+			<VinylControlBar className="vinyl__control-bar">
 				<div className="vinyl__media-controls">
-					<MediaPlayButton></MediaPlayButton>
-					<MediaSeekBackwardButton></MediaSeekBackwardButton>
-					<MediaSeekForwardButton></MediaSeekForwardButton>
+					<VinylPlayButton></VinylPlayButton>
+					<VinylSeekBackwardButton></VinylSeekBackwardButton>
+					<VinylSeekForwardButton></VinylSeekForwardButton>
 				</div>
 				<div className="vinyl__media-range">
-					<MediaTimeRange></MediaTimeRange>
-					<MediaTimeDisplay showDuration></MediaTimeDisplay>
+					<VinylTimeRange></VinylTimeRange>
+					<VinylTimeDisplay showDuration></VinylTimeDisplay>
 				</div>
 				<div className="vinyl__media-sound">
-					<MediaPlaybackRateButton></MediaPlaybackRateButton>
-					<MediaMuteButton></MediaMuteButton>
-					<MediaVolumeRange></MediaVolumeRange>
+					<VinylPlaybackRateButton></VinylPlaybackRateButton>
+					<VinylMuteButton></VinylMuteButton>
+					<VinylVolumeRange></VinylVolumeRange>
 				</div>
-			</MediaControlBar>
-		</MediaController>
+			</VinylControlBar>
+		</VinylController>
 	);
 }

--- a/src/audio/save.tsx
+++ b/src/audio/save.tsx
@@ -1,17 +1,18 @@
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import type { BlockSaveProps } from '@wordpress/blocks';
+
 import {
-	MediaPlaybackRateButton,
-	MediaController,
-	MediaControlBar,
-	MediaTimeRange,
-	MediaTimeDisplay,
-	MediaVolumeRange,
-	MediaPlayButton,
-	MediaSeekBackwardButton,
-	MediaSeekForwardButton,
-	MediaMuteButton,
-} from 'media-chrome/dist/react';
+	VinylController,
+	VinylControlBar,
+	VinylMuteButton,
+	VinylPlayButton,
+	VinylPlaybackRateButton,
+	VinylSeekBackwardButton,
+	VinylSeekForwardButton,
+	VinylTimeRange,
+	VinylTimeDisplay,
+	VinylVolumeRange,
+} from '../react/index.js';
 
 import type { Attributes } from './types';
 
@@ -21,7 +22,7 @@ export default function Save({ attributes }: BlockSaveProps<Attributes>) {
 	return (
 		src && (
 			<figure {...useBlockProps.save()}>
-				<MediaController
+				<VinylController
 					audio={true}
 					autohide="-1"
 					className="vinyl__player"
@@ -32,23 +33,23 @@ export default function Save({ attributes }: BlockSaveProps<Attributes>) {
 						preload={preload}
 						loop={loop}
 					/>
-					<MediaControlBar className="vinyl__control-bar">
+					<VinylControlBar className="vinyl__control-bar">
 						<div className="vinyl__media-controls">
-							<MediaPlayButton></MediaPlayButton>
-							<MediaSeekBackwardButton></MediaSeekBackwardButton>
-							<MediaSeekForwardButton></MediaSeekForwardButton>
+							<VinylPlayButton></VinylPlayButton>
+							<VinylSeekBackwardButton></VinylSeekBackwardButton>
+							<VinylSeekForwardButton></VinylSeekForwardButton>
 						</div>
 						<div className="vinyl__media-range">
-							<MediaTimeRange></MediaTimeRange>
-							<MediaTimeDisplay showDuration></MediaTimeDisplay>
+							<VinylTimeRange></VinylTimeRange>
+							<VinylTimeDisplay showDuration></VinylTimeDisplay>
 						</div>
 						<div className="vinyl__media-sound">
-							<MediaPlaybackRateButton></MediaPlaybackRateButton>
-							<MediaMuteButton></MediaMuteButton>
-							<MediaVolumeRange></MediaVolumeRange>
+							<VinylPlaybackRateButton></VinylPlaybackRateButton>
+							<VinylMuteButton></VinylMuteButton>
+							<VinylVolumeRange></VinylVolumeRange>
 						</div>
-					</MediaControlBar>
-				</MediaController>
+					</VinylControlBar>
+				</VinylController>
 				{hasCaption(attributes) && (
 					<RichText.Content
 						tagName="figcaption"

--- a/src/audio/style.scss
+++ b/src/audio/style.scss
@@ -48,7 +48,7 @@
 		justify-content: space-between;
 		align-items: center;
 
-		media-time-range {
+		vinyl-time-range {
 			width: 100%;
 		}
 

--- a/src/audio/transforms.ts
+++ b/src/audio/transforms.ts
@@ -1,7 +1,7 @@
 import { createBlobURL } from '@wordpress/blob';
 import { createBlock, type Block } from '@wordpress/blocks';
 
-import { Attributes } from './types';
+import type { Attributes } from './types';
 
 type Transforms = Block<Attributes>['transforms'];
 

--- a/src/audio/view.tsx
+++ b/src/audio/view.tsx
@@ -1,6 +1,6 @@
 // import { render } from '@wordpress/element';
 
-import 'media-chrome';
+import '../media-chrome.js';
 
 // window.addEventListener('load', () => {
 // 	const container = document.querySelector('.wp-block-vinyl-audio');

--- a/src/labels/create-labels.js
+++ b/src/labels/create-labels.js
@@ -1,0 +1,63 @@
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+export default function createLabels() {
+	const nouns = {
+		AUDIO_PLAYER: () => __('audio player', 'vinyl'),
+		VIDEO_PLAYER: () => __('video player', 'vinyl'),
+		VOLUME: () => __('volume', 'vinyl'),
+		SEEK: () => __('seek', 'vinyl'),
+		CLOSED_CAPTIONS: () => __('closed captions', 'vinyl'),
+		PLAYBACK_RATE: ({ playbackRate = 1 } = {}) =>
+			/* translators: ratio in the format of 1.0x, 1.5x, 2.0x etc. */
+			sprintf('current playback rate %s', playbackRate),
+		PLAYBACK_TIME: () => __('playback time', 'vinyl'),
+		MEDIA_LOADING: () => __('media loading', 'vinyl'),
+		SETTINGS: () => __('settings', 'vinyl'),
+		AUDIO_TRACKS: () => __('audio tracks', 'vinyl'),
+		QUALITY: () => __('quality', 'vinyl'),
+	};
+
+	const verbs = {
+		PLAY: () => __('play', 'vinyl'),
+		PAUSE: () => __('pause', 'vinyl'),
+		MUTE: () => __('mute', 'vinyl'),
+		UNMUTE: () => __('unmute', 'vinyl'),
+		ENTER_AIRPLAY: () => __('start airplay', 'vinyl'),
+		EXIT_AIRPLAY: () => __('stop airplay', 'vinyl'),
+		ENTER_CAST: () => __('start casting', 'vinyl'),
+		EXIT_CAST: () => __('stop casting', 'vinyl'),
+		ENTER_FULLSCREEN: () => __('enter fullscreen mode', 'vinyl'),
+		EXIT_FULLSCREEN: () => __('exit fullscreen mode', 'vinyl'),
+		ENTER_PIP: () => __('enter picture in picture mode', 'vinyl'),
+		EXIT_PIP: () => __('exit picture in picture mode', 'vinyl'),
+		SEEK_FORWARD_N_SECS: ({ seekOffset = 30 } = {}) =>
+			sprintf(
+				/* translators: number of seconds to seek forward. */
+				_n(
+					'seek forward %s second',
+					'seek forward %s seconds',
+					seekOffset,
+					'vinyl'
+				),
+				seekOffset
+			),
+		SEEK_BACK_N_SECS: ({ seekOffset = 30 } = {}) =>
+			sprintf(
+				/* translators: number of seconds to seek backward. */
+				_n(
+					'seek back %s second',
+					'seek back %s seconds',
+					seekOffset,
+					'vinyl'
+				),
+				seekOffset
+			),
+		SEEK_LIVE: () => __('seek to live', 'vinyl'),
+		PLAYING_LIVE: () => __('playing live', 'vinyl'),
+	};
+
+	return {
+		nouns,
+		verbs,
+	};
+}

--- a/src/labels/index.js
+++ b/src/labels/index.js
@@ -1,0 +1,3 @@
+import createLabels from './create-labels.js';
+
+export default createLabels();

--- a/src/media-chrome.js
+++ b/src/media-chrome.js
@@ -1,0 +1,11 @@
+// Only import the components we need.
+import './web-components/vinyl-controller.js';
+import './web-components/vinyl-control-bar.js';
+import './web-components/vinyl-time-range.js';
+import './web-components/vinyl-time-display.js';
+import './web-components/vinyl-volume-range.js';
+import './web-components/vinyl-play-button.js';
+import './web-components/vinyl-playback-rate-button.js';
+import './web-components/vinyl-seek-backward-button.js';
+import './web-components/vinyl-seek-forward-button.js';
+import './web-components/vinyl-mute-button.js';

--- a/src/react/common/utils.js
+++ b/src/react/common/utils.js
@@ -1,0 +1,74 @@
+/* eslint-disable */
+// @ts-nocheck
+
+/**
+ * This file is a modified version of the `scripts/react/common/utils.js` file
+ * from the `media-chrome` package.
+ *
+ * The original file can be found at the following link:
+ *
+ * https://github.com/muxinc/media-chrome/blob/692be61a2a63ba98c7e449d860ce1828b78353a2/scripts/react/common/utils.js
+ */
+
+/**
+ * Copyright (c) 2020 Mux, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const ReactPropToAttrNameMap = {
+	className: 'class',
+	classname: 'class',
+	htmlFor: 'for',
+	crossOrigin: 'crossorigin',
+	viewBox: 'viewBox',
+};
+
+export const toNativeAttrName = (propName, propValue) => {
+	if (ReactPropToAttrNameMap[propName])
+		return ReactPropToAttrNameMap[propName];
+	if (typeof propValue === undefined) return undefined;
+	if (typeof propValue === 'boolean' && !propValue) return undefined;
+	if (/[A-Z]/.test(propName)) return propName.toLowerCase();
+	return propName;
+};
+
+export const toNativeAttrValue = (propValue, _propName) => {
+	if (typeof propValue === 'boolean') return '';
+	if (Array.isArray(propValue)) return propValue.join(' ');
+	return propValue;
+};
+
+export const toNativeProps = (props = {}) => {
+	return Object.entries(props).reduce(
+		(transformedProps, [propName, propValue]) => {
+			const attrName = toNativeAttrName(propName, propValue);
+
+			// prop was stripped. Don't add.
+			if (!attrName) {
+				return transformedProps;
+			}
+
+			const attrValue = toNativeAttrValue(propValue, propName);
+			transformedProps[attrName] = attrValue;
+			return transformedProps;
+		},
+		{}
+	);
+};

--- a/src/react/index.d.ts
+++ b/src/react/index.d.ts
@@ -1,0 +1,58 @@
+/* eslint-disable */
+// @ts-nocheck
+
+import type React from 'react';
+
+import type * as CSS from 'csstype';
+declare global {
+  interface Element {
+    slot?: string;
+  }
+}
+
+declare module 'csstype' {
+  interface Properties {
+    // Should add generic support for any CSS variables
+    [index: `--${string}`]: any;
+  }
+}
+
+type GenericProps = { [k: string]: any };
+type GenericElement = HTMLElement;
+
+type GenericForwardRef = React.ForwardRefExoticComponent<
+  GenericProps & React.RefAttributes<GenericElement | undefined>
+>;
+
+declare const VinylContainer: GenericForwardRef;
+export { VinylContainer };
+
+declare const VinylControlBar: GenericForwardRef;
+export { VinylControlBar };
+
+declare const VinylController: GenericForwardRef;
+export { VinylController };
+
+declare const VinylMuteButton: GenericForwardRef;
+export { VinylMuteButton };
+
+declare const VinylPlayButton: GenericForwardRef;
+export { VinylPlayButton };
+
+declare const VinylPlaybackRateButton: GenericForwardRef;
+export { VinylPlaybackRateButton };
+
+declare const VinylSeekBackwardButton: GenericForwardRef;
+export { VinylSeekBackwardButton };
+
+declare const VinylSeekForwardButton: GenericForwardRef;
+export { VinylSeekForwardButton };
+
+declare const VinylTimeDisplay: GenericForwardRef;
+export { VinylTimeDisplay };
+
+declare const VinylTimeRange: GenericForwardRef;
+export { VinylTimeRange };
+
+declare const VinylVolumeRange: GenericForwardRef;
+export { VinylVolumeRange };

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,0 +1,83 @@
+/* eslint-disable */
+// @ts-nocheck
+
+import React from "react";
+import "../web-components/index.js";
+import { toNativeProps } from "./common/utils.js";
+
+/** @type { import("react").HTMLElement } */
+const VinylContainer = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-container', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylContainer };
+
+/** @type { import("react").HTMLElement } */
+const VinylControlBar = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-control-bar', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylControlBar };
+
+/** @type { import("react").HTMLElement } */
+const VinylController = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-controller', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylController };
+
+/** @type { import("react").HTMLElement } */
+const VinylMuteButton = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-mute-button', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylMuteButton };
+
+/** @type { import("react").HTMLElement } */
+const VinylPlayButton = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-play-button', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylPlayButton };
+
+/** @type { import("react").HTMLElement } */
+const VinylPlaybackRateButton = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-playback-rate-button', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylPlaybackRateButton };
+
+/** @type { import("react").HTMLElement } */
+const VinylSeekBackwardButton = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-seek-backward-button', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylSeekBackwardButton };
+
+/** @type { import("react").HTMLElement } */
+const VinylSeekForwardButton = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-seek-forward-button', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylSeekForwardButton };
+
+/** @type { import("react").HTMLElement } */
+const VinylTimeDisplay = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-time-display', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylTimeDisplay };
+
+/** @type { import("react").HTMLElement } */
+const VinylTimeRange = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-time-range', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylTimeRange };
+
+/** @type { import("react").HTMLElement } */
+const VinylVolumeRange = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-volume-range', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylVolumeRange };

--- a/src/utils/element-utils.js
+++ b/src/utils/element-utils.js
@@ -1,0 +1,62 @@
+/**
+ * @param {any}    svg      Should be an SVGElement, but need any for SSR cases
+ * @param {string} value
+ * @param {string} selector
+ */
+export const updateIconText = (svg, value, selector = '.value') => {
+	const node = svg.querySelector(selector);
+
+	if (!node) return;
+
+	node.textContent = value;
+};
+
+/**
+ *
+ * @param {any}    el   Should be an HTMLElement, but need any for SSR cases
+ * @param {string} name
+ */
+export const getAllSlotted = (el, name) => {
+	const slotSelector = `slot[name="${name}"]`;
+	const slot = el.shadowRoot.querySelector(slotSelector);
+	if (!slot) return [];
+	return slot.children;
+};
+
+export const getSlotted = (el, name) => getAllSlotted(el, name)[0];
+
+/**
+ * Gets the number represented by the attribute
+ * @param {any}    el                          Should be an HTMLElement, but need any for SSR cases
+ * @param {string} attrName
+ * @param {number} [defaultValue = Number.NaN]
+ *
+ * @returns {number | undefined} Will return undefined if no attribute set
+ */
+export function getNumericAttr(el, attrName, defaultValue = Number.NaN) {
+	const attrVal = el.getAttribute(attrName);
+	return attrVal !== null ? +attrVal : defaultValue;
+}
+
+/**
+ * @param {any}                       el       (Should be an HTMLElement, but need any for SSR cases)
+ * @param {string}                    attrName
+ * @param {number | null | undefined} value
+ */
+export function setNumericAttr(el, attrName, value) {
+	// Simple cast to number
+	const nextNumericValue = Number(value);
+
+	// Treat null, undefined, and NaN as "nothing values", so unset if value is currently set.
+	if (value === null || Number.isNaN(nextNumericValue)) {
+		if (el.hasAttribute(attrName)) {
+			el.removeAttribute(attrName);
+		}
+		return;
+	}
+
+	// Avoid resetting a value that hasn't changed
+	if (getNumericAttr(el, attrName, undefined) === nextNumericValue) return;
+
+	el.setAttribute(attrName, `${nextNumericValue}`);
+}

--- a/src/utils/server-safe-globals.js
+++ b/src/utils/server-safe-globals.js
@@ -1,0 +1,174 @@
+/* eslint-disable */
+// @ts-nocheck
+
+/**
+ * This file is a modified version of the `server-safe-globals.js` file from the
+ * `media-chrome` package. The purpose of duplicating this file is to allow the
+ * building of the reactified version of the Vinyl web components.
+ *
+ * Eslint and Typescript checks are disabled in this file because it is a direct
+ * copy of the original file with minor modifications. The original file can be
+ * found at the following link:
+ *
+ * https://github.com/muxinc/media-chrome/blob/692be61a2a63ba98c7e449d860ce1828b78353a2/src/js/utils/server-safe-globals.js
+ */
+
+/**
+ * Copyright (c) 2020 Mux, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+class EventTarget {
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() {
+    return true;
+  }
+}
+
+class Node extends EventTarget {}
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const documentShim = {
+  createElement: function () {
+    return new globalThisShim.HTMLElement();
+  },
+  createElementNS: function () {
+    return new globalThisShim.HTMLElement();
+  },
+  addEventListener() {},
+  removeEventListener() {},
+  /**
+   *
+   * @param {Event} event
+   * @returns {boolean}
+   */
+  dispatchEvent(event) { return false; }, // eslint-disable-line no-unused-vars
+};
+
+const globalThisShim = {
+  ResizeObserver,
+  document: documentShim,
+  Node: Node,
+  HTMLElement: class HTMLElement extends Node {},
+  DocumentFragment: class DocumentFragment extends EventTarget {},
+  customElements: {
+    get: function () {},
+    define: function () {},
+    whenDefined: function () {},
+  },
+  localStorage: {
+    /**
+     * @param {string} key
+     * @returns {string|null}
+    */
+    getItem(key) { return null; }, // eslint-disable-line no-unused-vars
+    /**
+     * @param {string} key
+     * @param {string} value
+     */
+    setItem(key, value) {}, // eslint-disable-line no-unused-vars
+    /**
+     * @param {string} key
+    */
+    removeItem(key) {}, // eslint-disable-line no-unused-vars
+  },
+  CustomEvent: function CustomEvent() {},
+  getComputedStyle: function () {},
+  navigator: {
+    languages: [],
+    get userAgent() {
+      return '';
+    }
+  },
+  /**
+   * @param {string} media
+   */
+  matchMedia(media) {
+    return {
+      matches: false,
+      media,
+    };
+  }
+};
+
+export const isServer =
+  typeof window === 'undefined' ||
+  typeof window.customElements === 'undefined';
+
+const isShimmed = Object.keys(globalThisShim)
+  .every(key => key in globalThis);
+
+/**
+  * @type { globalThis & {
+  *   WebKitPlaybackTargetAvailabilityEvent?,
+  *   chrome?,
+  *   DocumentFragment?,
+  *   getComputedStyle,
+  *   CastableVideoElement?
+  * } |
+  * {Node,
+  * HTMLElement,
+  * customElements,
+  * CustomEvent,
+  * getComputedStyle,
+  * addEventListener?,
+  * removeEventListener?,
+  * localStorage?,
+  * WebKitPlaybackTargetAvailabilityEvent?,
+  * window?,
+  * document?,
+  * chrome?,
+  * DocumentFragment?,
+  * ResizeObserver?,
+  * CastableVideoElement?,
+  * navigator?,
+  * matchMedia,
+  * } }
+  * */
+export const GlobalThis = isServer && !isShimmed ? globalThisShim : globalThis;
+
+/**
+  * @type { document & { webkitExitFullscreen? } |
+  * {createElement,
+  * createElementNS?,
+  * activeElement?,
+  * fullscreenElement?,
+  * webkitExitFullscreen?,
+  * getElementById?,
+  * pictureInPictureElement?,
+  * exitPictureInPicture?,
+  * pictureInPictureEnabled?,
+  * requestPictureInPicture?,
+  * addEventListener?,
+  * removeEventListener?,
+  * } }
+  */
+export const Document = isServer && !isShimmed ? documentShim : globalThis.document;
+
+export {
+  GlobalThis as globalThis,
+  Document as document
+};

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,178 @@
+/**
+ * This file is a modified version of the `time.js` file from the `media-chrome`
+ * package. The purpose of duplicating this file is to add custom translatable
+ * label support to the Vinyl player.
+ *
+ * The original file can be found at the following link:
+ *
+ * https://github.com/muxinc/media-chrome/blob/80a4780759c8c2cad2ae815671dac4ac7a92c4ab/src/js/utils/utils.js
+ */
+
+/**
+ * Copyright (c) 2020 Mux, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import { __ } from '@wordpress/i18n';
+import { isValidNumber } from 'media-chrome/dist/utils/utils.js';
+
+const UnitLabels = [
+	{
+		singular: __('hour', 'vinyl'),
+		plural: __('hours', 'vinyl'),
+	},
+	{
+		singular: __('minute', 'vinyl'),
+		plural: __('minutes', 'vinyl'),
+	},
+	{
+		singular: __('second', 'vinyl'),
+		plural: __('seconds', 'vinyl'),
+	},
+];
+
+const toTimeUnitPhrase = (timeUnitValue, unitIndex) => {
+	const unitLabel =
+		timeUnitValue === 1
+			? UnitLabels[unitIndex].singular
+			: UnitLabels[unitIndex].plural;
+
+	return `${timeUnitValue} ${unitLabel}`;
+};
+
+/**
+ * This function converts numeric seconds into a phrase
+ * @param {number} seconds - a (positive or negative) time, represented as seconds
+ * @returns {string} The time, represented as a phrase of hours, minutes, and seconds
+ */
+export const formatAsTimePhrase = (seconds) => {
+	if (!isValidNumber(seconds)) return '';
+	const positiveSeconds = Math.abs(seconds);
+	const negative = positiveSeconds !== seconds;
+	const secondsDateTime = new Date(0, 0, 0, 0, 0, positiveSeconds, 0);
+	const timeParts = [
+		secondsDateTime.getHours(),
+		secondsDateTime.getMinutes(),
+		secondsDateTime.getSeconds(),
+	];
+	// NOTE: Everything above should be useable for the `formatTime` function.
+
+	const timeString = timeParts
+		// Convert non-0 values to a string of the value plus its unit
+		.map(
+			(timeUnitValue, index) =>
+				timeUnitValue && toTimeUnitPhrase(timeUnitValue, index)
+		)
+		// Ignore/exclude any 0 values
+		.filter((x) => x)
+		// join into a single comma-separated string phrase
+		.join(', ');
+
+	// If the time was negative, assume it represents some remaining amount of time/"count down".
+	const negativeSuffix = negative ? ' remaining' : '';
+
+	return `${timeString}${negativeSuffix}`;
+};
+
+/**
+ * @description Converts a time, in numeric seconds, to a formatted string representation of the form [HH:[MM:]]SS, where hours and minutes
+ * are optional, either based on the value of `seconds` or (optionally) based on the value of `guide`.
+ * @param {number} seconds - The total time you'd like formatted, in seconds
+ * @param {number} [guide] - A number in seconds that represents how many units you'd want to show. This ensures consistent formatting between e.g. 35s and 4834s.
+ * @returns {string} A string representation of the time, with expected units
+ */
+export function formatTime(seconds, guide) {
+	// Handle negative values at the end
+	let negative = false;
+
+	if (seconds < 0) {
+		negative = true;
+		seconds = 0 - seconds;
+	}
+
+	seconds = seconds < 0 ? 0 : seconds;
+	/** @type {number|string} */
+	let s = Math.floor(seconds % 60);
+	/** @type {number|string} */
+	let m = Math.floor((seconds / 60) % 60);
+	/** @type {number|string} */
+	let h = Math.floor(seconds / 3600);
+	const gm = Math.floor((guide / 60) % 60);
+	const gh = Math.floor(guide / 3600);
+
+	// handle invalid times
+	if (isNaN(seconds) || seconds === Infinity) {
+		// '-' is false for all relational operators (e.g. <, >=) so this setting
+		// will add the minimum number of fields specified by the guide
+		h = m = s = '0';
+	}
+
+	// Check if we need to show hours
+	// @ts-expect-error
+	h = h > 0 || gh > 0 ? h + ':' : '';
+
+	// If hours are showing, we may need to add a leading zero.
+	// Always show at least one digit of minutes.
+	// @ts-expect-error
+	m = ((h || gm >= 10) && m < 10 ? '0' + m : m) + ':';
+
+	// Check if leading zero is need for seconds
+	// @ts-expect-error
+	s = s < 10 ? '0' + s : s;
+
+	return (negative ? '-' : '') + h + m + s;
+}
+
+/** @type {TimeRanges} */
+export const emptyTimeRanges = Object.freeze({
+	length: 0,
+	start(index) {
+		const unsignedIdx = index >>> 0;
+		if (unsignedIdx >= this.length) {
+			throw new DOMException(
+				`Failed to execute 'start' on 'TimeRanges': The index provided (${unsignedIdx}) is greater than or equal to the maximum bound (${this.length}).`
+			);
+		}
+		return 0;
+	},
+	end(index) {
+		const unsignedIdx = index >>> 0;
+		if (unsignedIdx >= this.length) {
+			throw new DOMException(
+				`Failed to execute 'end' on 'TimeRanges': The index provided (${unsignedIdx}) is greater than or equal to the maximum bound (${this.length}).`
+			);
+		}
+		return 0;
+	},
+});
+
+/**
+ * @param {TimeRanges} [timeRanges]
+ */
+export function serializeTimeRanges(timeRanges = emptyTimeRanges) {
+	// @ts-expect-error
+	return Array.from(timeRanges)
+		.map((_, i) =>
+			[
+				Number(timeRanges.start(i).toFixed(3)),
+				Number(timeRanges.end(i).toFixed(3)),
+			].join(':')
+		)
+		.join(' ');
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,8 @@
+/**
+ * @param {unknown} x The value to check
+ *
+ * @returns {x is number} Whether the value is a valid number
+ */
+export function isValidNumber(x) {
+	return typeof x === 'number' && !Number.isNaN(x) && Number.isFinite(x);
+}

--- a/src/web-components/index.js
+++ b/src/web-components/index.js
@@ -1,0 +1,11 @@
+export { default as VinylContainer } from './vinyl-container.js';
+export { default as VinylControlBar } from './vinyl-control-bar.js';
+export { default as VinylController } from './vinyl-controller.js';
+export { default as VinylMuteButton } from './vinyl-mute-button.js';
+export { default as VinylPlayButton } from './vinyl-play-button.js';
+export { default as VinylPlaybackRateButton } from './vinyl-playback-rate-button.js';
+export { default as VinylSeekBackwardButton } from './vinyl-seek-backward-button.js';
+export { default as VinylSeekForwardButton } from './vinyl-seek-forward-button.js';
+export { default as VinylTimeDisplay } from './vinyl-time-display.js';
+export { default as VinylTimeRange } from './vinyl-time-range.js';
+export { default as VinylVolumeRange } from './vinyl-volume-range.js';

--- a/src/web-components/vinyl-container.js
+++ b/src/web-components/vinyl-container.js
@@ -1,4 +1,3 @@
-import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
 import {
 	MediaContainer,
 	Attributes,
@@ -6,8 +5,6 @@ import {
 
 import labels from '../labels/index.js';
 import { globalThis } from '../utils/server-safe-globals.js';
-
-const MEDIA_UI_ATTRIBUTE_NAMES = Object.values(MediaUIAttributes);
 
 /**
  * The container component for the media player.
@@ -29,23 +26,6 @@ const MEDIA_UI_ATTRIBUTE_NAMES = Object.values(MediaUIAttributes);
  * @cssproperty --media-slot-display - `display` of the media slot (default none for [audio] usage).
  */
 class VinylContainer extends MediaContainer {
-	static get observedAttributes() {
-		return (
-			[Attributes.AUTOHIDE, Attributes.GESTURES_DISABLED]
-				.concat(MEDIA_UI_ATTRIBUTE_NAMES)
-				// Filter out specific / complex data media UI attributes
-				// that shouldn't be propagated to this state receiver element.
-				.filter(
-					(name) =>
-						![
-							MediaUIAttributes.MEDIA_RENDITION_LIST,
-							MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST,
-							MediaUIAttributes.MEDIA_CHAPTERS_CUES,
-						].includes(name)
-				)
-		);
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 

--- a/src/web-components/vinyl-container.js
+++ b/src/web-components/vinyl-container.js
@@ -1,0 +1,66 @@
+import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
+import {
+	MediaContainer,
+	Attributes,
+} from 'media-chrome/dist/media-container.js';
+
+import labels from '../labels/index.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+
+const MEDIA_UI_ATTRIBUTE_NAMES = Object.values(MediaUIAttributes);
+
+/**
+ * The container component for the media player.
+ *
+ * This component extends the `MediaContainer` component from `media-chrome` and
+ * add translatable `aria-label` attribute for the container.
+ *
+ * @augments {MediaContainer}
+ *
+ * @attr {boolean} audio
+ * @attr {string} autohide
+ * @attr {string} breakpoints
+ * @attr {boolean} gesturesdisabled
+ * @attr {boolean} keyboardcontrol
+ * @attr {boolean} noautohide
+ * @attr {boolean} userinactive
+ *
+ * @cssproperty --media-background-color - `background-color` of container.
+ * @cssproperty --media-slot-display - `display` of the media slot (default none for [audio] usage).
+ */
+class VinylContainer extends MediaContainer {
+	static get observedAttributes() {
+		return (
+			[Attributes.AUTOHIDE, Attributes.GESTURES_DISABLED]
+				.concat(MEDIA_UI_ATTRIBUTE_NAMES)
+				// Filter out specific / complex data media UI attributes
+				// that shouldn't be propagated to this state receiver element.
+				.filter(
+					(name) =>
+						![
+							MediaUIAttributes.MEDIA_RENDITION_LIST,
+							MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST,
+							MediaUIAttributes.MEDIA_CHAPTERS_CUES,
+						].includes(name)
+				)
+		);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+
+		const isAudioChrome = this.getAttribute(Attributes.AUDIO) !== null;
+		const label = isAudioChrome
+			? labels.nouns.AUDIO_PLAYER()
+			: labels.nouns.VIDEO_PLAYER();
+
+		this.setAttribute('aria-label', label);
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-container')) {
+	globalThis.customElements.define('vinyl-container', VinylContainer);
+}
+
+export { VinylContainer };
+export default VinylContainer;

--- a/src/web-components/vinyl-control-bar.js
+++ b/src/web-components/vinyl-control-bar.js
@@ -1,0 +1,94 @@
+import { MediaStateReceiverAttributes } from 'media-chrome/dist/constants.js';
+
+import { document, globalThis } from '../utils/server-safe-globals.js';
+
+const template = document.createElement('template');
+
+template.innerHTML = /*html*/ `
+  <style>
+    :host {
+      ${/* Need position to display above video for some reason */ ''}
+      box-sizing: border-box;
+      display: var(--media-control-display, var(--media-control-bar-display, inline-flex));
+      color: var(--media-text-color, var(--media-primary-color, rgb(238 238 238)));
+      --media-loading-indicator-icon-height: 44px;
+    }
+
+    ::slotted(media-time-range),
+    ::slotted(media-volume-range) {
+      min-height: 100%;
+    }
+
+    ::slotted(media-time-range),
+    ::slotted(media-clip-selector) {
+      flex-grow: 1;
+    }
+  </style>
+
+  <slot></slot>
+`;
+
+/**
+ * @attr {string} mediacontroller - The element `id` of the media controller to connect to (if not nested within).
+ *
+ * @cssproperty --media-primary-color - Default color of text and icon.
+ * @cssproperty --media-secondary-color - Default color of button background.
+ * @cssproperty --media-text-color - `color` of button text.
+ *
+ * @cssproperty --media-control-bar-display - `display` property of control bar.
+ * @cssproperty --media-control-display - `display` property of control.
+ */
+class VinylControlBar extends globalThis.HTMLElement {
+	#mediaController;
+
+	static get observedAttributes() {
+		return [MediaStateReceiverAttributes.MEDIA_CONTROLLER];
+	}
+
+	constructor() {
+		super();
+
+		if (!this.shadowRoot) {
+			// Set up the Shadow DOM if not using Declarative Shadow DOM.
+			this.attachShadow({ mode: 'open' });
+			this.shadowRoot.appendChild(template.content.cloneNode(true));
+		}
+	}
+
+	attributeChangedCallback(attrName, oldValue, newValue) {
+		if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
+			if (oldValue) {
+				this.#mediaController?.unassociateElement?.(this);
+				this.#mediaController = null;
+			}
+			if (newValue && this.isConnected) {
+				this.#mediaController =
+					this.getRootNode()?.getElementById(newValue);
+				this.#mediaController?.associateElement?.(this);
+			}
+		}
+	}
+
+	connectedCallback() {
+		const mediaControllerId = this.getAttribute(
+			MediaStateReceiverAttributes.MEDIA_CONTROLLER
+		);
+		if (mediaControllerId) {
+			this.#mediaController =
+				this.getRootNode()?.getElementById(mediaControllerId);
+			this.#mediaController?.associateElement?.(this);
+		}
+	}
+
+	disconnectedCallback() {
+		// Use cached mediaController, getRootNode() doesn't work if disconnected.
+		this.#mediaController?.unassociateElement?.(this);
+		this.#mediaController = null;
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-control-bar')) {
+	globalThis.customElements.define('vinyl-control-bar', VinylControlBar);
+}
+
+export default VinylControlBar;

--- a/src/web-components/vinyl-controller.js
+++ b/src/web-components/vinyl-controller.js
@@ -1,0 +1,815 @@
+/* eslint-disable */
+// @ts-nocheck
+
+/**
+ * This file is a modified version of the `media-controller.js` file from the
+ * `media-chrome` package. The purpose of duplicating this file is to add custom
+ * translatable label support to the Vinyl player.
+ *
+ * Eslint and Typescript checks are disabled in this file because it is a direct
+ * copy of the original file with minor modifications. The original file can be
+ * found at the following link:
+ *
+ * https://github.com/muxinc/media-chrome/blob/80a4780759c8c2cad2ae815671dac4ac7a92c4ab/src/js/media-controller.js#L583
+ */
+
+/**
+ * Copyright (c) 2020 Mux, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {
+	MediaUIEvents,
+	MediaUIAttributes,
+	MediaStateReceiverAttributes,
+	AttributeToStateChangeEventMap,
+	MediaUIProps,
+} from 'media-chrome/dist/constants.js';
+import { Attributes } from 'media-chrome/dist/media-controller.js';
+import createMediaStore from 'media-chrome/dist/media-store/media-store.js';
+import { AttributeTokenList } from 'media-chrome/dist/utils/attribute-token-list.js';
+import { stringifyTextTrackList } from 'media-chrome/dist/utils/captions.js';
+import {
+	setBooleanAttr,
+	setNumericAttr,
+	setStringAttr,
+} from 'media-chrome/dist/utils/element-utils.js';
+import {
+	delay,
+	stringifyRenditionList,
+	stringifyAudioTrackList,
+} from 'media-chrome/dist/utils/utils.js';
+
+import { VinylContainer } from './vinyl-container.js';
+import { document, globalThis } from '../utils/server-safe-globals.js';
+
+const ButtonPressedKeys = ['ArrowLeft', 'ArrowRight', 'Enter', ' ', 'f', 'm', 'k', 'c'];
+const DEFAULT_SEEK_OFFSET = 10;
+
+/**
+ * Media Controller should not mimic the HTMLMediaElement API.
+ * @see https://github.com/muxinc/media-chrome/pull/182#issuecomment-1067370339
+ *
+ * @attr {boolean} defaultsubtitles
+ * @attr {string} defaultstreamtype
+ * @attr {string} defaultduration
+ * @attr {string} fullscreenelement
+ * @attr {boolean} nohotkeys
+ * @attr {string} hotkeys
+ * @attr {string} keysused
+ * @attr {string} liveedgeoffset
+ * @attr {boolean} noautoseektolive
+ * @attr {boolean} novolumepref
+ * @attr {boolean} nosubtitleslangpref
+ * @attr {boolean} nodefaultstore
+ */
+class VinylController extends VinylContainer {
+	static get observedAttributes() {
+    return super.observedAttributes.concat(
+      Attributes.NO_HOTKEYS,
+      Attributes.HOTKEYS,
+      Attributes.DEFAULT_STREAM_TYPE,
+      Attributes.DEFAULT_SUBTITLES,
+      Attributes.DEFAULT_DURATION,
+    );
+  }
+
+  #hotKeys = new AttributeTokenList(this, Attributes.HOTKEYS);
+  #fullscreenElement;
+  #mediaStore;
+  #mediaStateCallback;
+  #mediaStoreUnsubscribe;
+  #mediaStateEventHandler = (event) => {
+    this.#mediaStore?.dispatch(event);
+  };
+
+  constructor() {
+    super();
+
+    // Track externally associated control elements
+    this.mediaStateReceivers = [];
+    this.associatedElementSubscriptions = new Map();
+    this.associateElement(this);
+
+    let prevState = {};
+    this.#mediaStateCallback = (nextState) => {
+      Object.entries(nextState).forEach(([stateName, stateValue]) => {
+        // Make sure to propagate initial state, even if still undefined (CJP)
+        if (stateName in prevState && prevState[stateName] === stateValue) return;
+        this.propagateMediaState(stateName, stateValue);
+        const attrName = stateName.toLowerCase();
+        const evt = new globalThis.CustomEvent(
+          AttributeToStateChangeEventMap[attrName],
+          { composed: true, detail: stateValue }
+        );
+
+        this.dispatchEvent(evt);
+      });
+      prevState = nextState;
+    };
+
+    this.enableHotkeys();
+  }
+
+  #setupDefaultStore() {
+    this.mediaStore = createMediaStore({
+      media: this.media,
+      fullscreenElement: this.fullscreenElement,
+      options: {
+        defaultSubtitles: this.hasAttribute(Attributes.DEFAULT_SUBTITLES),
+        defaultDuration: this.hasAttribute(Attributes.DEFAULT_DURATION) ? +this.getAttribute(Attributes.DEFAULT_DURATION) : undefined,
+        defaultStreamType: /** @type {import('./media-store/state-mediator.js').StreamTypeValue} */ (this.getAttribute(Attributes.DEFAULT_STREAM_TYPE)) ?? undefined,
+        liveEdgeOffset: this.hasAttribute(Attributes.LIVE_EDGE_OFFSET) ? +this.getAttribute(Attributes.LIVE_EDGE_OFFSET) : undefined,
+        // NOTE: This wasn't updated if it was changed later. Should it be? (CJP)
+        noVolumePref: this.hasAttribute(Attributes.NO_VOLUME_PREF),
+        noSubtitlesLangPref: this.hasAttribute(Attributes.NO_SUBTITLES_LANG_PREF),
+      },
+    });
+  }
+
+  get mediaStore() {
+    return this.#mediaStore;
+  }
+
+  set mediaStore(value) {
+    if (this.#mediaStore) {
+      this.#mediaStoreUnsubscribe?.();
+      this.#mediaStoreUnsubscribe = undefined;
+    }
+    this.#mediaStore = value;
+
+    if (!this.#mediaStore && !this.hasAttribute(Attributes.NO_DEFAULT_STORE)) {
+      this.#setupDefaultStore();
+      return;
+    }
+
+    this.#mediaStoreUnsubscribe = this.#mediaStore?.subscribe(this.#mediaStateCallback);
+  }
+
+  get fullscreenElement() {
+    return this.#fullscreenElement ?? this;
+  }
+
+  set fullscreenElement(element) {
+    if (this.hasAttribute(Attributes.FULLSCREEN_ELEMENT)) {
+      this.removeAttribute(Attributes.FULLSCREEN_ELEMENT);
+    }
+    this.#fullscreenElement = element;
+    // Use the getter in case the fullscreen element was reset to "`this`"
+    this.#mediaStore?.dispatch({ type: 'fullscreenelementchangerequest', detail: this.fullscreenElement });
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+
+    if (attrName === Attributes.NO_HOTKEYS) {
+      if (newValue !== oldValue && newValue === '') {
+        if (this.hasAttribute(Attributes.HOTKEYS)) {
+          console.warn('Media Chrome: Both `hotkeys` and `nohotkeys` have been set. All hotkeys will be disabled.');
+        }
+        this.disableHotkeys();
+
+      } else if (newValue !== oldValue && newValue === null) {
+        this.enableHotkeys();
+      }
+    } else if (attrName === Attributes.HOTKEYS) {
+        this.#hotKeys.value = newValue;
+
+    } else if (
+      attrName === Attributes.DEFAULT_SUBTITLES &&
+      newValue !== oldValue
+    ) {
+      this.#mediaStore?.dispatch({
+        type: 'optionschangerequest',
+        detail: {
+          defaultSubtitles: this.hasAttribute(Attributes.DEFAULT_SUBTITLES),
+        },
+      });
+
+    } else if (attrName === Attributes.DEFAULT_STREAM_TYPE) {
+      this.#mediaStore?.dispatch({
+        type: 'optionschangerequest',
+        detail: {
+          defaultStreamType: this.getAttribute(Attributes.DEFAULT_STREAM_TYPE) ?? undefined,
+        },
+      });
+    } else if (attrName === Attributes.LIVE_EDGE_OFFSET) {
+      this.#mediaStore?.dispatch({
+        type: 'optionschangerequest',
+        detail: {
+          liveEdgeOffset: this.hasAttribute(Attributes.LIVE_EDGE_OFFSET)
+            ? +this.getAttribute(Attributes.LIVE_EDGE_OFFSET)
+            : undefined,
+        },
+      });
+    } else if (attrName === Attributes.FULLSCREEN_ELEMENT) {
+      const el = newValue
+        ? (/** @type {Document|ShadowRoot} */ (/** @type {unknown} */ this.getRootNode()))?.getElementById(newValue)
+        : undefined;
+
+      // NOTE: Setting the internal private prop here instead of using the setter to not
+      // clear the attribute that was just set (CJP).
+      this.#fullscreenElement = el;
+      // Use the getter in case the fullscreen element was reset to "`this`"
+      this.#mediaStore?.dispatch({ type: 'fullscreenelementchangerequest', detail: this.fullscreenElement });
+    }
+  }
+
+  connectedCallback() {
+
+    // NOTE: Need to defer default MediaStore creation until connected for use cases that
+    // rely on createElement('media-controller') (like many frameworks "under the hood") (CJP).
+    if (!this.#mediaStore && !this.hasAttribute(Attributes.NO_DEFAULT_STORE)) {
+      this.#setupDefaultStore();
+    }
+
+    this.#mediaStore?.dispatch({ type: 'documentelementchangerequest', detail: document });
+
+    // mediaSetCallback() is called in super.connectedCallback();
+    super.connectedCallback();
+
+    if (this.#mediaStore && !this.#mediaStoreUnsubscribe) {
+      this.#mediaStoreUnsubscribe = this.#mediaStore?.subscribe(this.#mediaStateCallback);
+    }
+
+    this.enableHotkeys();
+  }
+
+  disconnectedCallback() {
+    // mediaUnsetCallback() is called in super.disconnectedCallback();
+    super.disconnectedCallback?.();
+
+    if (this.#mediaStore) {
+      this.#mediaStore?.dispatch({ type: 'documentelementchangerequest', detail: undefined });
+      /** @TODO Revisit: may not be necessary anymore or better solved via unsubscribe behavior? (CJP) */
+      // Disable captions on disconnect to prevent a memory leak if they stay enabled.
+      this.#mediaStore?.dispatch({
+        type: MediaUIEvents.MEDIA_TOGGLE_SUBTITLES_REQUEST,
+        detail: false
+      });
+    }
+
+    if (this.#mediaStoreUnsubscribe) {
+      this.#mediaStoreUnsubscribe?.();
+      this.#mediaStoreUnsubscribe = undefined;
+    }
+  }
+
+  /**
+   * @override
+   * @param {HTMLMediaElement} media
+   */
+  mediaSetCallback(media) {
+    super.mediaSetCallback(media);
+    this.#mediaStore?.dispatch({ type: 'mediaelementchangerequest', detail: media });
+
+    // TODO: What does this do? At least add comment, maybe move to media-container
+    if (!media.hasAttribute('tabindex')) {
+      media.tabIndex = -1;
+    }
+  }
+
+  /**
+   * @override
+   * @param {HTMLMediaElement} media
+   */
+  mediaUnsetCallback(media) {
+    super.mediaUnsetCallback(media);
+    this.#mediaStore?.dispatch({ type: 'mediaelementchangerequest', detail: undefined });
+  }
+
+  propagateMediaState(stateName, state) {
+    propagateMediaState(this.mediaStateReceivers, stateName, state);
+  }
+
+  associateElement(element) {
+    if (!element) return;
+    const { associatedElementSubscriptions } = this;
+
+    if (associatedElementSubscriptions.has(element)) return;
+
+    const registerMediaStateReceiver =
+      this.registerMediaStateReceiver.bind(this);
+    const unregisterMediaStateReceiver =
+      this.unregisterMediaStateReceiver.bind(this);
+
+    /** @TODO Should we support "removing association" */
+    const unsubscribe = monitorForMediaStateReceivers(
+      element,
+      registerMediaStateReceiver,
+      unregisterMediaStateReceiver
+    );
+
+    // Add all media request event listeners to the Associated Element. This allows any DOM element that
+    // is a descendant of any Associated Element (including the <media-controller/> itself) to make requests
+    // for media state changes rather than constraining that exclusively to a Media State Receivers.
+    // Still generically setup events -> mediaStore dispatch, since it will
+    // forward the events on to whichever store is defined (CJP)
+    Object.values(MediaUIEvents).forEach(eventName => {
+      element.addEventListener(eventName, this.#mediaStateEventHandler);
+    });
+
+    associatedElementSubscriptions.set(element, unsubscribe);
+  }
+
+  unassociateElement(element) {
+    if (!element) return;
+    const { associatedElementSubscriptions } = this;
+    if (!associatedElementSubscriptions.has(element)) return;
+    const unsubscribe = associatedElementSubscriptions.get(element);
+    unsubscribe();
+    associatedElementSubscriptions.delete(element);
+
+    // Remove all media UI event listeners
+    Object.values(MediaUIEvents).forEach(eventName => {
+      element.removeEventListener(eventName, this.#mediaStateEventHandler);
+    });
+  }
+
+  registerMediaStateReceiver(el) {
+		console.log('registerMediaStateReceiver', el.nodeName);
+    if (!el) return;
+    const els = this.mediaStateReceivers;
+    const index = els.indexOf(el);
+    if (index > -1) return;
+
+    els.push(el);
+
+    if (this.#mediaStore) {
+      Object.entries(this.#mediaStore.getState()).forEach(([stateName, stateValue]) => {
+        propagateMediaState([el], stateName, stateValue);
+      });
+    }
+  }
+
+  unregisterMediaStateReceiver(el) {
+    const els = this.mediaStateReceivers;
+
+    const index = els.indexOf(el);
+    if (index < 0) return;
+
+    els.splice(index, 1);
+  }
+
+  #keyUpHandler(e) {
+    const { key } = e;
+    if (!ButtonPressedKeys.includes(key)) {
+      this.removeEventListener('keyup', this.#keyUpHandler);
+      return;
+    }
+
+    this.keyboardShortcutHandler(e);
+  }
+
+  #keyDownHandler(e) {
+    const { metaKey, altKey, key } = e;
+    if (metaKey || altKey || !ButtonPressedKeys.includes(key)) {
+      this.removeEventListener('keyup', this.#keyUpHandler);
+      return;
+    }
+
+    // if the pressed key might move the page, we need to preventDefault on keydown
+    // because doing so on keyup is too late
+    // We also want to make sure that the hotkey hasn't been turned off before doing so
+    if (
+      [' ', 'ArrowLeft', 'ArrowRight'].includes(key) &&
+      !(this.#hotKeys.contains(`no${key.toLowerCase()}`) ||
+        key === ' ' && this.#hotKeys.contains('nospace'))
+    ) {
+      e.preventDefault();
+    }
+
+    this.addEventListener('keyup', this.#keyUpHandler, {once: true});
+  }
+
+  enableHotkeys() {
+    this.addEventListener('keydown', this.#keyDownHandler);
+  }
+
+  disableHotkeys() {
+    this.removeEventListener('keydown', this.#keyDownHandler);
+    this.removeEventListener('keyup', this.#keyUpHandler);
+  }
+
+  get hotkeys() {
+    return this.#hotKeys;
+  }
+
+  keyboardShortcutHandler(e) {
+    // TODO: e.target might need to be replaced w/ e.composedPath to account for shadow DOM.
+    // if the event's key is already handled by the target, skip keyboard shortcuts
+    // keysUsed is either an attribute or a property.
+    // The attribute is a DOM array and the property is a JS array
+    // In the attribute Space represents the space key and gets convered to ' '
+    const keysUsed = (e.target.getAttribute(Attributes.KEYS_USED)?.split(' ') ?? e.target?.keysUsed ?? [])
+      .map(key => key === 'Space' ? ' ' : key)
+      .filter(Boolean);
+
+    if (keysUsed.includes(e.key)) {
+      return;
+    }
+
+    let eventName, detail, evt;
+    // if the blocklist contains the key, skip handling it.
+    if (this.#hotKeys.contains(`no${e.key.toLowerCase()}`)) return;
+    if (e.key === ' ' && this.#hotKeys.contains(`nospace`)) return;
+
+    // These event triggers were copied from the revelant buttons
+    switch (e.key) {
+      case ' ':
+      case 'k':
+        eventName = this.#mediaStore.getState().mediaPaused
+          ? MediaUIEvents.MEDIA_PLAY_REQUEST
+          : MediaUIEvents.MEDIA_PAUSE_REQUEST;
+        this.dispatchEvent(
+          new globalThis.CustomEvent(eventName, { composed: true, bubbles: true })
+        );
+        break;
+
+      case 'm':
+        eventName = this.mediaStore.getState().mediaVolumeLevel === 'off'
+            ? MediaUIEvents.MEDIA_UNMUTE_REQUEST
+            : MediaUIEvents.MEDIA_MUTE_REQUEST;
+        this.dispatchEvent(
+          new globalThis.CustomEvent(eventName, { composed: true, bubbles: true })
+        );
+        break;
+
+      case 'f':
+        eventName = this.mediaStore.getState().mediaIsFullscreen
+            ? MediaUIEvents.MEDIA_EXIT_FULLSCREEN_REQUEST
+            : MediaUIEvents.MEDIA_ENTER_FULLSCREEN_REQUEST;
+        this.dispatchEvent(
+          new globalThis.CustomEvent(eventName, { composed: true, bubbles: true })
+        );
+        break;
+
+      case 'c':
+        this.dispatchEvent(
+          new globalThis.CustomEvent(
+            MediaUIEvents.MEDIA_TOGGLE_SUBTITLES_REQUEST,
+            { composed: true, bubbles: true }
+          )
+        );
+        break;
+
+      case 'ArrowLeft': {
+        const offsetValue = this.hasAttribute(Attributes.KEYBOARD_BACKWARD_SEEK_OFFSET)
+          ? +this.getAttribute(Attributes.KEYBOARD_BACKWARD_SEEK_OFFSET)
+          : DEFAULT_SEEK_OFFSET;
+        detail = Math.max((this.mediaStore.getState().mediaCurrentTime ?? 0) - offsetValue, 0);
+        evt = new globalThis.CustomEvent(MediaUIEvents.MEDIA_SEEK_REQUEST, {
+          composed: true,
+          bubbles: true,
+          detail,
+        });
+        this.dispatchEvent(evt);
+        break;
+      }
+      case 'ArrowRight': {
+        const offsetValue = this.hasAttribute(Attributes.KEYBOARD_FORWARD_SEEK_OFFSET)
+          ? +this.getAttribute(Attributes.KEYBOARD_FORWARD_SEEK_OFFSET)
+          : DEFAULT_SEEK_OFFSET;
+        detail = Math.max((this.mediaStore.getState().mediaCurrentTime ?? 0) + offsetValue, 0);
+        evt = new globalThis.CustomEvent(MediaUIEvents.MEDIA_SEEK_REQUEST, {
+          composed: true,
+          bubbles: true,
+          detail,
+        });
+        this.dispatchEvent(evt);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}
+
+const MEDIA_UI_ATTRIBUTE_NAMES = Object.values(MediaUIAttributes);
+const MEDIA_UI_PROP_NAMES = Object.values(MediaUIProps);
+
+/**
+ * @template {HTMLElement} T
+ *
+ * @param {T} child
+ *
+ * @returns {string[]}
+ */
+const getMediaUIAttributesFrom = (child) => {
+  let { observedAttributes } = child.constructor;
+
+  // observedAttributes are only available if the custom element was upgraded.
+  // example: media-gesture-receiver in the shadow DOM requires an upgrade.
+  if (!observedAttributes && child.nodeName?.includes('-')) {
+    globalThis.customElements.upgrade(child);
+    ({ observedAttributes } = child.constructor);
+  }
+
+  const mediaChromeAttributesList = child
+    ?.getAttribute?.(MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES)
+    ?.split?.(/\s+/);
+
+  if (!Array.isArray(observedAttributes || mediaChromeAttributesList))
+    return [];
+  return (observedAttributes || mediaChromeAttributesList).filter((attrName) =>
+    MEDIA_UI_ATTRIBUTE_NAMES.includes(attrName)
+  );
+};
+
+/**
+ * @template {HTMLElement} T
+ *
+ * @param {T} mediaStateReceiverCandidate
+ *
+ * @returns {boolean}
+ */
+const hasMediaUIProps = (mediaStateReceiverCandidate) => {
+  if (
+    mediaStateReceiverCandidate.nodeName?.includes('-')
+    && !!globalThis.customElements.get(mediaStateReceiverCandidate.nodeName?.toLowerCase())
+    && !(mediaStateReceiverCandidate instanceof globalThis.customElements.get(mediaStateReceiverCandidate.nodeName.toLowerCase()))
+  ) {
+    globalThis.customElements.upgrade(mediaStateReceiverCandidate);
+  }
+  return MEDIA_UI_PROP_NAMES.some(propName => propName in mediaStateReceiverCandidate);
+};
+
+/**
+ * @template {HTMLElement} T
+ *
+ * @param {T} child
+ *
+ * @returns {boolean}
+ */
+const isMediaStateReceiver = (child) => {
+	// TODO this is where things are going wrong.
+  return hasMediaUIProps(child) || !!getMediaUIAttributesFrom(child).length;
+};
+
+const serializeTuple = (tuple) => tuple?.join?.(':');
+
+const CustomAttrSerializer = {
+  [MediaUIAttributes.MEDIA_SUBTITLES_LIST]: stringifyTextTrackList,
+  [MediaUIAttributes.MEDIA_SUBTITLES_SHOWING]: stringifyTextTrackList,
+  [MediaUIAttributes.MEDIA_SEEKABLE]: serializeTuple,
+  [MediaUIAttributes.MEDIA_BUFFERED]: (tuples) => tuples?.map(serializeTuple).join(' '),
+  [MediaUIAttributes.MEDIA_PREVIEW_COORDS]: (coords) => coords?.join(' '),
+  [MediaUIAttributes.MEDIA_RENDITION_LIST]: stringifyRenditionList,
+  [MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST]: stringifyAudioTrackList,
+};
+
+const setAttr = async (child, attrName, attrValue) => {
+  // If the node is not connected to the DOM yet wait on macrotask. Fix for:
+  //   Uncaught DOMException: Failed to construct 'CustomElement':
+  //   The result must not have attributes
+  if (!child.isConnected) {
+    await delay(0);
+  }
+
+  // NOTE: For "nullish" (null/undefined), can use any setter
+  if (typeof attrValue === 'boolean' || attrValue == null) {
+    return setBooleanAttr(child, attrName, attrValue);
+  }
+  if (typeof attrValue === 'number') {
+    return setNumericAttr(child, attrName, attrValue)
+  }
+  if (typeof attrValue === 'string') {
+    return setStringAttr(child, attrName, attrValue);
+  }
+  // Treat empty arrays as "nothing" values
+  if (Array.isArray(attrValue) && !attrValue.length) {
+    return child.removeAttribute(attrName);
+  }
+
+  // For "special" values with custom serializers or all other values
+  const val = CustomAttrSerializer[attrName]?.(attrValue) ?? attrValue;
+  return child.setAttribute(attrName, val);
+};
+
+const isMediaSlotElementDescendant = (el) => !!el.closest?.('*[slot="media"]');
+
+/**
+ *
+ * @description This function will recursively check for any descendants (including the rootNode)
+ * that are Media State Receivers and invoke `mediaStateReceiverCallback` with any Media State Receiver
+ * found
+ *
+ * @param {HTMLElement} rootNode
+ * @param {function} mediaStateReceiverCallback
+ */
+const traverseForMediaStateReceivers = (
+  rootNode,
+  mediaStateReceiverCallback
+) => {
+  // We (currently) don't check if descendants of the `media` (e.g. <video/>) are Media State Receivers
+  // See also: `propagateMediaState`
+  if (isMediaSlotElementDescendant(rootNode)) {
+    return;
+  }
+
+	console.log('traverseForMediaStateReceivers', rootNode.nodeName)
+
+	/**
+	 * @template {HTMLElement} T
+	 * @param {T} rootNode
+	 * @param {Function} mediaStateReceiverCallback
+	 */
+  const traverseForMediaStateReceiversSync = (
+    rootNode,
+    mediaStateReceiverCallback
+  ) => {
+    // The rootNode is itself a Media State Receiver
+    if (isMediaStateReceiver(rootNode)) {
+      mediaStateReceiverCallback(rootNode);
+    }
+
+		console.log('isMediaStateReceiver', rootNode.nodeName, isMediaStateReceiver(rootNode))
+
+    const { children = [] } = rootNode ?? {};
+    const shadowChildren = rootNode?.shadowRoot?.children ?? [];
+    const allChildren = [...children, ...shadowChildren];
+
+    // Traverse all children (including shadowRoot children) to see if they are/have Media State Receivers
+    allChildren.forEach((child) =>
+      traverseForMediaStateReceivers(child, mediaStateReceiverCallback)
+    );
+  };
+
+  // Custom Elements (and *only* Custom Elements) must have a hyphen ("-") in their name. So, if the rootNode is
+  // a custom element (aka has a hyphen in its name), wait until it's defined before attempting traversal to determine
+  // whether or not it or its descendants are Media State Receivers.
+  // IMPORTANT NOTE: We're intentionally *always* waiting for the `whenDefined()` Promise to resolve here
+  // (instead of using `globalThis.customElements.get(name)` to check if a custom element is already defined/registered)
+  // because we encountered some reliability issues with the custom element instances not being fully "ready", even if/when
+  // they are available in the registry via `globalThis.customElements.get(name)`.
+  const name = rootNode?.nodeName.toLowerCase();
+  if (name.includes('-') && !isMediaStateReceiver(rootNode)) {
+
+    globalThis.customElements.whenDefined(name).then(() => {
+      // Try/traverse again once the custom element is defined
+      traverseForMediaStateReceiversSync(rootNode, mediaStateReceiverCallback);
+    });
+    return;
+  }
+
+  traverseForMediaStateReceiversSync(rootNode, mediaStateReceiverCallback);
+};
+
+const propagateMediaState = (els, stateName, val) => {
+  els.forEach((el) => {
+    if (stateName in el) {
+      el[stateName] = val;
+      return;
+    }
+    const relevantAttrs = getMediaUIAttributesFrom(el);
+    const attrName = stateName.toLowerCase();
+    if (!relevantAttrs.includes(attrName)) return;
+    setAttr(el, attrName, val);
+  });
+};
+
+/**
+ *
+ * @description This function will monitor the rootNode for any Media State Receiver descendants
+ * that are already present, added, or removed, invoking the relevant callback function for each
+ * case.
+ *
+ * @param {HTMLElement} rootNode
+ * @param {function} registerMediaStateReceiver
+ * @param {function} unregisterMediaStateReceiver
+ * @returns An unsubscribe method, used to stop monitoring descendants of rootNode and to unregister its descendants
+ *
+ */
+const monitorForMediaStateReceivers = (
+  rootNode,
+  registerMediaStateReceiver,
+  unregisterMediaStateReceiver
+) => {
+  // First traverse the tree to register any current Media State Receivers
+  traverseForMediaStateReceivers(rootNode, registerMediaStateReceiver);
+
+  // Monitor for any event-based requests from descendants to register/unregister as a Media State Receiver
+  const registerMediaStateReceiverHandler = (evt) => {
+    const el = evt?.composedPath()[0] ?? evt.target;
+    registerMediaStateReceiver(el);
+  };
+
+  const unregisterMediaStateReceiverHandler = (evt) => {
+    const el = evt?.composedPath()[0] ?? evt.target;
+    unregisterMediaStateReceiver(el);
+  };
+
+  rootNode.addEventListener(
+    MediaUIEvents.REGISTER_MEDIA_STATE_RECEIVER,
+    registerMediaStateReceiverHandler
+  );
+  rootNode.addEventListener(
+    MediaUIEvents.UNREGISTER_MEDIA_STATE_RECEIVER,
+    unregisterMediaStateReceiverHandler
+  );
+
+  // Observe any changes to the DOM for any descendants that are identifiable as Media State Receivers
+  // and register or unregister them, depending on the change that occurred.
+  const mutationCallback = (mutationsList) => {
+    mutationsList.forEach((mutationRecord) => {
+			console.log('mutationRecord', mutationRecord.target?.nodeName, mutationRecord.attributeName);
+      const {
+        addedNodes = [],
+        removedNodes = [],
+        type,
+        target,
+        attributeName,
+      } = mutationRecord;
+      if (type === 'childList') {
+        // For each added node, register any Media State Receiver descendants (including itself)
+        Array.prototype.forEach.call(addedNodes, (node) =>
+          traverseForMediaStateReceivers(node, registerMediaStateReceiver)
+        );
+        // For each removed node, unregister any Media State Receiver descendants (including itself)
+        Array.prototype.forEach.call(removedNodes, (node) =>
+          traverseForMediaStateReceivers(node, unregisterMediaStateReceiver)
+        );
+      } else if (
+        type === 'attributes' &&
+        attributeName === MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES
+      ) {
+				console.log('mutationCallback', target.nodeName, isMediaStateReceiver(target))
+
+        if (isMediaStateReceiver(target)) {
+          // Changed from a "non-Media State Receiver" to a Media State Receiver: register it.
+					console.log(target.nodeName)
+          registerMediaStateReceiver(target);
+        } else {
+          // Changed from a Media State Receiver to a "non-Media State Receiver": unregister it.
+          unregisterMediaStateReceiver(target);
+        }
+      }
+    });
+  };
+
+  // Storing prevSlotted elements so we can cleanup if slotted elements change over time.
+  let prevSlotted = [];
+  const slotChangeHandler = (event) => {
+    const slotEl = /** @type {HTMLSlotElement} */ event.target;
+    if (slotEl.name === "media") return;
+    prevSlotted.forEach((node) =>
+      traverseForMediaStateReceivers(node, unregisterMediaStateReceiver)
+    );
+    prevSlotted = /** @type {HTMLElement[]} */ ([...slotEl.assignedElements({ flatten: true })]);
+    prevSlotted.forEach((node) =>
+      traverseForMediaStateReceivers(node, registerMediaStateReceiver)
+    );
+  };
+  rootNode.addEventListener('slotchange', slotChangeHandler);
+
+  const observer = new MutationObserver(mutationCallback);
+  observer.observe(rootNode, {
+    childList: true,
+    attributes: true,
+    subtree: true,
+  });
+
+  const unsubscribe = () => {
+    // Unregister any Media State Receiver descendants (including ourselves)
+    traverseForMediaStateReceivers(rootNode, unregisterMediaStateReceiver);
+    // Make sure we remove the slotchange event listener
+    rootNode.removeEventListener('slotchange', slotChangeHandler);
+    // Stop observing for Media State Receivers
+    observer.disconnect();
+    // Stop listening for Media State Receiver events.
+    rootNode.removeEventListener(
+      MediaUIEvents.REGISTER_MEDIA_STATE_RECEIVER,
+      registerMediaStateReceiverHandler
+    );
+    rootNode.removeEventListener(
+      MediaUIEvents.UNREGISTER_MEDIA_STATE_RECEIVER,
+      unregisterMediaStateReceiverHandler
+    );
+  };
+
+  return unsubscribe;
+};
+
+if (!globalThis.customElements.get('vinyl-controller')) {
+	globalThis.customElements.define('vinyl-controller', VinylController);
+}
+
+export { VinylController };
+export default VinylController;

--- a/src/web-components/vinyl-controller.js
+++ b/src/web-components/vinyl-controller.js
@@ -60,7 +60,16 @@ import {
 import { VinylContainer } from './vinyl-container.js';
 import { document, globalThis } from '../utils/server-safe-globals.js';
 
-const ButtonPressedKeys = ['ArrowLeft', 'ArrowRight', 'Enter', ' ', 'f', 'm', 'k', 'c'];
+const ButtonPressedKeys = [
+	'ArrowLeft',
+	'ArrowRight',
+	'Enter',
+	' ',
+	'f',
+	'm',
+	'k',
+	'c',
+];
 const DEFAULT_SEEK_OFFSET = 10;
 
 /**
@@ -82,424 +91,515 @@ const DEFAULT_SEEK_OFFSET = 10;
  */
 class VinylController extends VinylContainer {
 	static get observedAttributes() {
-    return super.observedAttributes.concat(
-      Attributes.NO_HOTKEYS,
-      Attributes.HOTKEYS,
-      Attributes.DEFAULT_STREAM_TYPE,
-      Attributes.DEFAULT_SUBTITLES,
-      Attributes.DEFAULT_DURATION,
-    );
-  }
+		return super.observedAttributes.concat(
+			Attributes.NO_HOTKEYS,
+			Attributes.HOTKEYS,
+			Attributes.DEFAULT_STREAM_TYPE,
+			Attributes.DEFAULT_SUBTITLES,
+			Attributes.DEFAULT_DURATION
+		);
+	}
 
-  #hotKeys = new AttributeTokenList(this, Attributes.HOTKEYS);
-  #fullscreenElement;
-  #mediaStore;
-  #mediaStateCallback;
-  #mediaStoreUnsubscribe;
-  #mediaStateEventHandler = (event) => {
-    this.#mediaStore?.dispatch(event);
-  };
+	#hotKeys = new AttributeTokenList(this, Attributes.HOTKEYS);
+	#fullscreenElement;
+	#mediaStore;
+	#mediaStateCallback;
+	#mediaStoreUnsubscribe;
+	#mediaStateEventHandler = (event) => {
+		this.#mediaStore?.dispatch(event);
+	};
 
-  constructor() {
-    super();
+	constructor() {
+		super();
 
-    // Track externally associated control elements
-    this.mediaStateReceivers = [];
-    this.associatedElementSubscriptions = new Map();
-    this.associateElement(this);
+		// Track externally associated control elements
+		this.mediaStateReceivers = [];
+		this.associatedElementSubscriptions = new Map();
+		this.associateElement(this);
 
-    let prevState = {};
-    this.#mediaStateCallback = (nextState) => {
-      Object.entries(nextState).forEach(([stateName, stateValue]) => {
-        // Make sure to propagate initial state, even if still undefined (CJP)
-        if (stateName in prevState && prevState[stateName] === stateValue) return;
-        this.propagateMediaState(stateName, stateValue);
-        const attrName = stateName.toLowerCase();
-        const evt = new globalThis.CustomEvent(
-          AttributeToStateChangeEventMap[attrName],
-          { composed: true, detail: stateValue }
-        );
+		let prevState = {};
+		this.#mediaStateCallback = (nextState) => {
+			Object.entries(nextState).forEach(([stateName, stateValue]) => {
+				// Make sure to propagate initial state, even if still undefined (CJP)
+				if (
+					stateName in prevState &&
+					prevState[stateName] === stateValue
+				)
+					return;
+				this.propagateMediaState(stateName, stateValue);
+				const attrName = stateName.toLowerCase();
+				const evt = new globalThis.CustomEvent(
+					AttributeToStateChangeEventMap[attrName],
+					{ composed: true, detail: stateValue }
+				);
 
-        this.dispatchEvent(evt);
-      });
-      prevState = nextState;
-    };
+				this.dispatchEvent(evt);
+			});
+			prevState = nextState;
+		};
 
-    this.enableHotkeys();
-  }
+		this.enableHotkeys();
+	}
 
-  #setupDefaultStore() {
-    this.mediaStore = createMediaStore({
-      media: this.media,
-      fullscreenElement: this.fullscreenElement,
-      options: {
-        defaultSubtitles: this.hasAttribute(Attributes.DEFAULT_SUBTITLES),
-        defaultDuration: this.hasAttribute(Attributes.DEFAULT_DURATION) ? +this.getAttribute(Attributes.DEFAULT_DURATION) : undefined,
-        defaultStreamType: /** @type {import('./media-store/state-mediator.js').StreamTypeValue} */ (this.getAttribute(Attributes.DEFAULT_STREAM_TYPE)) ?? undefined,
-        liveEdgeOffset: this.hasAttribute(Attributes.LIVE_EDGE_OFFSET) ? +this.getAttribute(Attributes.LIVE_EDGE_OFFSET) : undefined,
-        // NOTE: This wasn't updated if it was changed later. Should it be? (CJP)
-        noVolumePref: this.hasAttribute(Attributes.NO_VOLUME_PREF),
-        noSubtitlesLangPref: this.hasAttribute(Attributes.NO_SUBTITLES_LANG_PREF),
-      },
-    });
-  }
+	#setupDefaultStore() {
+		this.mediaStore = createMediaStore({
+			media: this.media,
+			fullscreenElement: this.fullscreenElement,
+			options: {
+				defaultSubtitles: this.hasAttribute(
+					Attributes.DEFAULT_SUBTITLES
+				),
+				defaultDuration: this.hasAttribute(Attributes.DEFAULT_DURATION)
+					? +this.getAttribute(Attributes.DEFAULT_DURATION)
+					: undefined,
+				defaultStreamType:
+					/** @type {import('./media-store/state-mediator.js').StreamTypeValue} */ (
+						this.getAttribute(Attributes.DEFAULT_STREAM_TYPE)
+					) ?? undefined,
+				liveEdgeOffset: this.hasAttribute(Attributes.LIVE_EDGE_OFFSET)
+					? +this.getAttribute(Attributes.LIVE_EDGE_OFFSET)
+					: undefined,
+				// NOTE: This wasn't updated if it was changed later. Should it be? (CJP)
+				noVolumePref: this.hasAttribute(Attributes.NO_VOLUME_PREF),
+				noSubtitlesLangPref: this.hasAttribute(
+					Attributes.NO_SUBTITLES_LANG_PREF
+				),
+			},
+		});
+	}
 
-  get mediaStore() {
-    return this.#mediaStore;
-  }
+	get mediaStore() {
+		return this.#mediaStore;
+	}
 
-  set mediaStore(value) {
-    if (this.#mediaStore) {
-      this.#mediaStoreUnsubscribe?.();
-      this.#mediaStoreUnsubscribe = undefined;
-    }
-    this.#mediaStore = value;
+	set mediaStore(value) {
+		if (this.#mediaStore) {
+			this.#mediaStoreUnsubscribe?.();
+			this.#mediaStoreUnsubscribe = undefined;
+		}
+		this.#mediaStore = value;
 
-    if (!this.#mediaStore && !this.hasAttribute(Attributes.NO_DEFAULT_STORE)) {
-      this.#setupDefaultStore();
-      return;
-    }
+		if (
+			!this.#mediaStore &&
+			!this.hasAttribute(Attributes.NO_DEFAULT_STORE)
+		) {
+			this.#setupDefaultStore();
+			return;
+		}
 
-    this.#mediaStoreUnsubscribe = this.#mediaStore?.subscribe(this.#mediaStateCallback);
-  }
+		this.#mediaStoreUnsubscribe = this.#mediaStore?.subscribe(
+			this.#mediaStateCallback
+		);
+	}
 
-  get fullscreenElement() {
-    return this.#fullscreenElement ?? this;
-  }
+	get fullscreenElement() {
+		return this.#fullscreenElement ?? this;
+	}
 
-  set fullscreenElement(element) {
-    if (this.hasAttribute(Attributes.FULLSCREEN_ELEMENT)) {
-      this.removeAttribute(Attributes.FULLSCREEN_ELEMENT);
-    }
-    this.#fullscreenElement = element;
-    // Use the getter in case the fullscreen element was reset to "`this`"
-    this.#mediaStore?.dispatch({ type: 'fullscreenelementchangerequest', detail: this.fullscreenElement });
-  }
+	set fullscreenElement(element) {
+		if (this.hasAttribute(Attributes.FULLSCREEN_ELEMENT)) {
+			this.removeAttribute(Attributes.FULLSCREEN_ELEMENT);
+		}
+		this.#fullscreenElement = element;
+		// Use the getter in case the fullscreen element was reset to "`this`"
+		this.#mediaStore?.dispatch({
+			type: 'fullscreenelementchangerequest',
+			detail: this.fullscreenElement,
+		});
+	}
 
-  attributeChangedCallback(attrName, oldValue, newValue) {
-    super.attributeChangedCallback(attrName, oldValue, newValue);
+	attributeChangedCallback(attrName, oldValue, newValue) {
+		super.attributeChangedCallback(attrName, oldValue, newValue);
 
-    if (attrName === Attributes.NO_HOTKEYS) {
-      if (newValue !== oldValue && newValue === '') {
-        if (this.hasAttribute(Attributes.HOTKEYS)) {
-          console.warn('Media Chrome: Both `hotkeys` and `nohotkeys` have been set. All hotkeys will be disabled.');
-        }
-        this.disableHotkeys();
+		if (attrName === Attributes.NO_HOTKEYS) {
+			if (newValue !== oldValue && newValue === '') {
+				if (this.hasAttribute(Attributes.HOTKEYS)) {
+					console.warn(
+						'Media Chrome: Both `hotkeys` and `nohotkeys` have been set. All hotkeys will be disabled.'
+					);
+				}
+				this.disableHotkeys();
+			} else if (newValue !== oldValue && newValue === null) {
+				this.enableHotkeys();
+			}
+		} else if (attrName === Attributes.HOTKEYS) {
+			this.#hotKeys.value = newValue;
+		} else if (
+			attrName === Attributes.DEFAULT_SUBTITLES &&
+			newValue !== oldValue
+		) {
+			this.#mediaStore?.dispatch({
+				type: 'optionschangerequest',
+				detail: {
+					defaultSubtitles: this.hasAttribute(
+						Attributes.DEFAULT_SUBTITLES
+					),
+				},
+			});
+		} else if (attrName === Attributes.DEFAULT_STREAM_TYPE) {
+			this.#mediaStore?.dispatch({
+				type: 'optionschangerequest',
+				detail: {
+					defaultStreamType:
+						this.getAttribute(Attributes.DEFAULT_STREAM_TYPE) ??
+						undefined,
+				},
+			});
+		} else if (attrName === Attributes.LIVE_EDGE_OFFSET) {
+			this.#mediaStore?.dispatch({
+				type: 'optionschangerequest',
+				detail: {
+					liveEdgeOffset: this.hasAttribute(
+						Attributes.LIVE_EDGE_OFFSET
+					)
+						? +this.getAttribute(Attributes.LIVE_EDGE_OFFSET)
+						: undefined,
+				},
+			});
+		} else if (attrName === Attributes.FULLSCREEN_ELEMENT) {
+			const el = newValue
+				? /** @type {Document|ShadowRoot} */ (
+						/** @type {unknown} */ this.getRootNode()
+					)?.getElementById(newValue)
+				: undefined;
 
-      } else if (newValue !== oldValue && newValue === null) {
-        this.enableHotkeys();
-      }
-    } else if (attrName === Attributes.HOTKEYS) {
-        this.#hotKeys.value = newValue;
+			// NOTE: Setting the internal private prop here instead of using the setter to not
+			// clear the attribute that was just set (CJP).
+			this.#fullscreenElement = el;
+			// Use the getter in case the fullscreen element was reset to "`this`"
+			this.#mediaStore?.dispatch({
+				type: 'fullscreenelementchangerequest',
+				detail: this.fullscreenElement,
+			});
+		}
+	}
 
-    } else if (
-      attrName === Attributes.DEFAULT_SUBTITLES &&
-      newValue !== oldValue
-    ) {
-      this.#mediaStore?.dispatch({
-        type: 'optionschangerequest',
-        detail: {
-          defaultSubtitles: this.hasAttribute(Attributes.DEFAULT_SUBTITLES),
-        },
-      });
+	connectedCallback() {
+		// NOTE: Need to defer default MediaStore creation until connected for use cases that
+		// rely on createElement('media-controller') (like many frameworks "under the hood") (CJP).
+		if (
+			!this.#mediaStore &&
+			!this.hasAttribute(Attributes.NO_DEFAULT_STORE)
+		) {
+			this.#setupDefaultStore();
+		}
 
-    } else if (attrName === Attributes.DEFAULT_STREAM_TYPE) {
-      this.#mediaStore?.dispatch({
-        type: 'optionschangerequest',
-        detail: {
-          defaultStreamType: this.getAttribute(Attributes.DEFAULT_STREAM_TYPE) ?? undefined,
-        },
-      });
-    } else if (attrName === Attributes.LIVE_EDGE_OFFSET) {
-      this.#mediaStore?.dispatch({
-        type: 'optionschangerequest',
-        detail: {
-          liveEdgeOffset: this.hasAttribute(Attributes.LIVE_EDGE_OFFSET)
-            ? +this.getAttribute(Attributes.LIVE_EDGE_OFFSET)
-            : undefined,
-        },
-      });
-    } else if (attrName === Attributes.FULLSCREEN_ELEMENT) {
-      const el = newValue
-        ? (/** @type {Document|ShadowRoot} */ (/** @type {unknown} */ this.getRootNode()))?.getElementById(newValue)
-        : undefined;
+		this.#mediaStore?.dispatch({
+			type: 'documentelementchangerequest',
+			detail: document,
+		});
 
-      // NOTE: Setting the internal private prop here instead of using the setter to not
-      // clear the attribute that was just set (CJP).
-      this.#fullscreenElement = el;
-      // Use the getter in case the fullscreen element was reset to "`this`"
-      this.#mediaStore?.dispatch({ type: 'fullscreenelementchangerequest', detail: this.fullscreenElement });
-    }
-  }
+		// mediaSetCallback() is called in super.connectedCallback();
+		super.connectedCallback();
 
-  connectedCallback() {
+		if (this.#mediaStore && !this.#mediaStoreUnsubscribe) {
+			this.#mediaStoreUnsubscribe = this.#mediaStore?.subscribe(
+				this.#mediaStateCallback
+			);
+		}
 
-    // NOTE: Need to defer default MediaStore creation until connected for use cases that
-    // rely on createElement('media-controller') (like many frameworks "under the hood") (CJP).
-    if (!this.#mediaStore && !this.hasAttribute(Attributes.NO_DEFAULT_STORE)) {
-      this.#setupDefaultStore();
-    }
+		this.enableHotkeys();
+	}
 
-    this.#mediaStore?.dispatch({ type: 'documentelementchangerequest', detail: document });
+	disconnectedCallback() {
+		// mediaUnsetCallback() is called in super.disconnectedCallback();
+		super.disconnectedCallback?.();
 
-    // mediaSetCallback() is called in super.connectedCallback();
-    super.connectedCallback();
+		if (this.#mediaStore) {
+			this.#mediaStore?.dispatch({
+				type: 'documentelementchangerequest',
+				detail: undefined,
+			});
+			/** @TODO Revisit: may not be necessary anymore or better solved via unsubscribe behavior? (CJP) */
+			// Disable captions on disconnect to prevent a memory leak if they stay enabled.
+			this.#mediaStore?.dispatch({
+				type: MediaUIEvents.MEDIA_TOGGLE_SUBTITLES_REQUEST,
+				detail: false,
+			});
+		}
 
-    if (this.#mediaStore && !this.#mediaStoreUnsubscribe) {
-      this.#mediaStoreUnsubscribe = this.#mediaStore?.subscribe(this.#mediaStateCallback);
-    }
+		if (this.#mediaStoreUnsubscribe) {
+			this.#mediaStoreUnsubscribe?.();
+			this.#mediaStoreUnsubscribe = undefined;
+		}
+	}
 
-    this.enableHotkeys();
-  }
+	/**
+	 * @override
+	 * @param {HTMLMediaElement} media
+	 */
+	mediaSetCallback(media) {
+		super.mediaSetCallback(media);
+		this.#mediaStore?.dispatch({
+			type: 'mediaelementchangerequest',
+			detail: media,
+		});
 
-  disconnectedCallback() {
-    // mediaUnsetCallback() is called in super.disconnectedCallback();
-    super.disconnectedCallback?.();
+		// TODO: What does this do? At least add comment, maybe move to media-container
+		if (!media.hasAttribute('tabindex')) {
+			media.tabIndex = -1;
+		}
+	}
 
-    if (this.#mediaStore) {
-      this.#mediaStore?.dispatch({ type: 'documentelementchangerequest', detail: undefined });
-      /** @TODO Revisit: may not be necessary anymore or better solved via unsubscribe behavior? (CJP) */
-      // Disable captions on disconnect to prevent a memory leak if they stay enabled.
-      this.#mediaStore?.dispatch({
-        type: MediaUIEvents.MEDIA_TOGGLE_SUBTITLES_REQUEST,
-        detail: false
-      });
-    }
+	/**
+	 * @override
+	 * @param {HTMLMediaElement} media
+	 */
+	mediaUnsetCallback(media) {
+		super.mediaUnsetCallback(media);
+		this.#mediaStore?.dispatch({
+			type: 'mediaelementchangerequest',
+			detail: undefined,
+		});
+	}
 
-    if (this.#mediaStoreUnsubscribe) {
-      this.#mediaStoreUnsubscribe?.();
-      this.#mediaStoreUnsubscribe = undefined;
-    }
-  }
+	propagateMediaState(stateName, state) {
+		propagateMediaState(this.mediaStateReceivers, stateName, state);
+	}
 
-  /**
-   * @override
-   * @param {HTMLMediaElement} media
-   */
-  mediaSetCallback(media) {
-    super.mediaSetCallback(media);
-    this.#mediaStore?.dispatch({ type: 'mediaelementchangerequest', detail: media });
+	associateElement(element) {
+		if (!element) return;
+		const { associatedElementSubscriptions } = this;
 
-    // TODO: What does this do? At least add comment, maybe move to media-container
-    if (!media.hasAttribute('tabindex')) {
-      media.tabIndex = -1;
-    }
-  }
+		if (associatedElementSubscriptions.has(element)) return;
 
-  /**
-   * @override
-   * @param {HTMLMediaElement} media
-   */
-  mediaUnsetCallback(media) {
-    super.mediaUnsetCallback(media);
-    this.#mediaStore?.dispatch({ type: 'mediaelementchangerequest', detail: undefined });
-  }
+		const registerMediaStateReceiver =
+			this.registerMediaStateReceiver.bind(this);
+		const unregisterMediaStateReceiver =
+			this.unregisterMediaStateReceiver.bind(this);
 
-  propagateMediaState(stateName, state) {
-    propagateMediaState(this.mediaStateReceivers, stateName, state);
-  }
+		/** @TODO Should we support "removing association" */
+		const unsubscribe = monitorForMediaStateReceivers(
+			element,
+			registerMediaStateReceiver,
+			unregisterMediaStateReceiver
+		);
 
-  associateElement(element) {
-    if (!element) return;
-    const { associatedElementSubscriptions } = this;
+		// Add all media request event listeners to the Associated Element. This allows any DOM element that
+		// is a descendant of any Associated Element (including the <media-controller/> itself) to make requests
+		// for media state changes rather than constraining that exclusively to a Media State Receivers.
+		// Still generically setup events -> mediaStore dispatch, since it will
+		// forward the events on to whichever store is defined (CJP)
+		Object.values(MediaUIEvents).forEach((eventName) => {
+			element.addEventListener(eventName, this.#mediaStateEventHandler);
+		});
 
-    if (associatedElementSubscriptions.has(element)) return;
+		associatedElementSubscriptions.set(element, unsubscribe);
+	}
 
-    const registerMediaStateReceiver =
-      this.registerMediaStateReceiver.bind(this);
-    const unregisterMediaStateReceiver =
-      this.unregisterMediaStateReceiver.bind(this);
+	unassociateElement(element) {
+		if (!element) return;
+		const { associatedElementSubscriptions } = this;
+		if (!associatedElementSubscriptions.has(element)) return;
+		const unsubscribe = associatedElementSubscriptions.get(element);
+		unsubscribe();
+		associatedElementSubscriptions.delete(element);
 
-    /** @TODO Should we support "removing association" */
-    const unsubscribe = monitorForMediaStateReceivers(
-      element,
-      registerMediaStateReceiver,
-      unregisterMediaStateReceiver
-    );
+		// Remove all media UI event listeners
+		Object.values(MediaUIEvents).forEach((eventName) => {
+			element.removeEventListener(
+				eventName,
+				this.#mediaStateEventHandler
+			);
+		});
+	}
 
-    // Add all media request event listeners to the Associated Element. This allows any DOM element that
-    // is a descendant of any Associated Element (including the <media-controller/> itself) to make requests
-    // for media state changes rather than constraining that exclusively to a Media State Receivers.
-    // Still generically setup events -> mediaStore dispatch, since it will
-    // forward the events on to whichever store is defined (CJP)
-    Object.values(MediaUIEvents).forEach(eventName => {
-      element.addEventListener(eventName, this.#mediaStateEventHandler);
-    });
+	registerMediaStateReceiver(el) {
+		if (!el) return;
+		const els = this.mediaStateReceivers;
+		const index = els.indexOf(el);
+		if (index > -1) return;
 
-    associatedElementSubscriptions.set(element, unsubscribe);
-  }
+		els.push(el);
 
-  unassociateElement(element) {
-    if (!element) return;
-    const { associatedElementSubscriptions } = this;
-    if (!associatedElementSubscriptions.has(element)) return;
-    const unsubscribe = associatedElementSubscriptions.get(element);
-    unsubscribe();
-    associatedElementSubscriptions.delete(element);
+		if (this.#mediaStore) {
+			Object.entries(this.#mediaStore.getState()).forEach(
+				([stateName, stateValue]) => {
+					propagateMediaState([el], stateName, stateValue);
+				}
+			);
+		}
+	}
 
-    // Remove all media UI event listeners
-    Object.values(MediaUIEvents).forEach(eventName => {
-      element.removeEventListener(eventName, this.#mediaStateEventHandler);
-    });
-  }
+	unregisterMediaStateReceiver(el) {
+		const els = this.mediaStateReceivers;
 
-  registerMediaStateReceiver(el) {
-		console.log('registerMediaStateReceiver', el.nodeName);
-    if (!el) return;
-    const els = this.mediaStateReceivers;
-    const index = els.indexOf(el);
-    if (index > -1) return;
+		const index = els.indexOf(el);
+		if (index < 0) return;
 
-    els.push(el);
+		els.splice(index, 1);
+	}
 
-    if (this.#mediaStore) {
-      Object.entries(this.#mediaStore.getState()).forEach(([stateName, stateValue]) => {
-        propagateMediaState([el], stateName, stateValue);
-      });
-    }
-  }
+	#keyUpHandler(e) {
+		const { key } = e;
+		if (!ButtonPressedKeys.includes(key)) {
+			this.removeEventListener('keyup', this.#keyUpHandler);
+			return;
+		}
 
-  unregisterMediaStateReceiver(el) {
-    const els = this.mediaStateReceivers;
+		this.keyboardShortcutHandler(e);
+	}
 
-    const index = els.indexOf(el);
-    if (index < 0) return;
+	#keyDownHandler(e) {
+		const { metaKey, altKey, key } = e;
+		if (metaKey || altKey || !ButtonPressedKeys.includes(key)) {
+			this.removeEventListener('keyup', this.#keyUpHandler);
+			return;
+		}
 
-    els.splice(index, 1);
-  }
+		// if the pressed key might move the page, we need to preventDefault on keydown
+		// because doing so on keyup is too late
+		// We also want to make sure that the hotkey hasn't been turned off before doing so
+		if (
+			[' ', 'ArrowLeft', 'ArrowRight'].includes(key) &&
+			!(
+				this.#hotKeys.contains(`no${key.toLowerCase()}`) ||
+				(key === ' ' && this.#hotKeys.contains('nospace'))
+			)
+		) {
+			e.preventDefault();
+		}
 
-  #keyUpHandler(e) {
-    const { key } = e;
-    if (!ButtonPressedKeys.includes(key)) {
-      this.removeEventListener('keyup', this.#keyUpHandler);
-      return;
-    }
+		this.addEventListener('keyup', this.#keyUpHandler, { once: true });
+	}
 
-    this.keyboardShortcutHandler(e);
-  }
+	enableHotkeys() {
+		this.addEventListener('keydown', this.#keyDownHandler);
+	}
 
-  #keyDownHandler(e) {
-    const { metaKey, altKey, key } = e;
-    if (metaKey || altKey || !ButtonPressedKeys.includes(key)) {
-      this.removeEventListener('keyup', this.#keyUpHandler);
-      return;
-    }
+	disableHotkeys() {
+		this.removeEventListener('keydown', this.#keyDownHandler);
+		this.removeEventListener('keyup', this.#keyUpHandler);
+	}
 
-    // if the pressed key might move the page, we need to preventDefault on keydown
-    // because doing so on keyup is too late
-    // We also want to make sure that the hotkey hasn't been turned off before doing so
-    if (
-      [' ', 'ArrowLeft', 'ArrowRight'].includes(key) &&
-      !(this.#hotKeys.contains(`no${key.toLowerCase()}`) ||
-        key === ' ' && this.#hotKeys.contains('nospace'))
-    ) {
-      e.preventDefault();
-    }
+	get hotkeys() {
+		return this.#hotKeys;
+	}
 
-    this.addEventListener('keyup', this.#keyUpHandler, {once: true});
-  }
+	keyboardShortcutHandler(e) {
+		// TODO: e.target might need to be replaced w/ e.composedPath to account for shadow DOM.
+		// if the event's key is already handled by the target, skip keyboard shortcuts
+		// keysUsed is either an attribute or a property.
+		// The attribute is a DOM array and the property is a JS array
+		// In the attribute Space represents the space key and gets convered to ' '
+		const keysUsed = (
+			e.target.getAttribute(Attributes.KEYS_USED)?.split(' ') ??
+			e.target?.keysUsed ??
+			[]
+		)
+			.map((key) => (key === 'Space' ? ' ' : key))
+			.filter(Boolean);
 
-  enableHotkeys() {
-    this.addEventListener('keydown', this.#keyDownHandler);
-  }
+		if (keysUsed.includes(e.key)) {
+			return;
+		}
 
-  disableHotkeys() {
-    this.removeEventListener('keydown', this.#keyDownHandler);
-    this.removeEventListener('keyup', this.#keyUpHandler);
-  }
+		let eventName, detail, evt;
+		// if the blocklist contains the key, skip handling it.
+		if (this.#hotKeys.contains(`no${e.key.toLowerCase()}`)) return;
+		if (e.key === ' ' && this.#hotKeys.contains(`nospace`)) return;
 
-  get hotkeys() {
-    return this.#hotKeys;
-  }
+		// These event triggers were copied from the revelant buttons
+		switch (e.key) {
+			case ' ':
+			case 'k':
+				eventName = this.#mediaStore.getState().mediaPaused
+					? MediaUIEvents.MEDIA_PLAY_REQUEST
+					: MediaUIEvents.MEDIA_PAUSE_REQUEST;
+				this.dispatchEvent(
+					new globalThis.CustomEvent(eventName, {
+						composed: true,
+						bubbles: true,
+					})
+				);
+				break;
 
-  keyboardShortcutHandler(e) {
-    // TODO: e.target might need to be replaced w/ e.composedPath to account for shadow DOM.
-    // if the event's key is already handled by the target, skip keyboard shortcuts
-    // keysUsed is either an attribute or a property.
-    // The attribute is a DOM array and the property is a JS array
-    // In the attribute Space represents the space key and gets convered to ' '
-    const keysUsed = (e.target.getAttribute(Attributes.KEYS_USED)?.split(' ') ?? e.target?.keysUsed ?? [])
-      .map(key => key === 'Space' ? ' ' : key)
-      .filter(Boolean);
+			case 'm':
+				eventName =
+					this.mediaStore.getState().mediaVolumeLevel === 'off'
+						? MediaUIEvents.MEDIA_UNMUTE_REQUEST
+						: MediaUIEvents.MEDIA_MUTE_REQUEST;
+				this.dispatchEvent(
+					new globalThis.CustomEvent(eventName, {
+						composed: true,
+						bubbles: true,
+					})
+				);
+				break;
 
-    if (keysUsed.includes(e.key)) {
-      return;
-    }
+			case 'f':
+				eventName = this.mediaStore.getState().mediaIsFullscreen
+					? MediaUIEvents.MEDIA_EXIT_FULLSCREEN_REQUEST
+					: MediaUIEvents.MEDIA_ENTER_FULLSCREEN_REQUEST;
+				this.dispatchEvent(
+					new globalThis.CustomEvent(eventName, {
+						composed: true,
+						bubbles: true,
+					})
+				);
+				break;
 
-    let eventName, detail, evt;
-    // if the blocklist contains the key, skip handling it.
-    if (this.#hotKeys.contains(`no${e.key.toLowerCase()}`)) return;
-    if (e.key === ' ' && this.#hotKeys.contains(`nospace`)) return;
+			case 'c':
+				this.dispatchEvent(
+					new globalThis.CustomEvent(
+						MediaUIEvents.MEDIA_TOGGLE_SUBTITLES_REQUEST,
+						{ composed: true, bubbles: true }
+					)
+				);
+				break;
 
-    // These event triggers were copied from the revelant buttons
-    switch (e.key) {
-      case ' ':
-      case 'k':
-        eventName = this.#mediaStore.getState().mediaPaused
-          ? MediaUIEvents.MEDIA_PLAY_REQUEST
-          : MediaUIEvents.MEDIA_PAUSE_REQUEST;
-        this.dispatchEvent(
-          new globalThis.CustomEvent(eventName, { composed: true, bubbles: true })
-        );
-        break;
-
-      case 'm':
-        eventName = this.mediaStore.getState().mediaVolumeLevel === 'off'
-            ? MediaUIEvents.MEDIA_UNMUTE_REQUEST
-            : MediaUIEvents.MEDIA_MUTE_REQUEST;
-        this.dispatchEvent(
-          new globalThis.CustomEvent(eventName, { composed: true, bubbles: true })
-        );
-        break;
-
-      case 'f':
-        eventName = this.mediaStore.getState().mediaIsFullscreen
-            ? MediaUIEvents.MEDIA_EXIT_FULLSCREEN_REQUEST
-            : MediaUIEvents.MEDIA_ENTER_FULLSCREEN_REQUEST;
-        this.dispatchEvent(
-          new globalThis.CustomEvent(eventName, { composed: true, bubbles: true })
-        );
-        break;
-
-      case 'c':
-        this.dispatchEvent(
-          new globalThis.CustomEvent(
-            MediaUIEvents.MEDIA_TOGGLE_SUBTITLES_REQUEST,
-            { composed: true, bubbles: true }
-          )
-        );
-        break;
-
-      case 'ArrowLeft': {
-        const offsetValue = this.hasAttribute(Attributes.KEYBOARD_BACKWARD_SEEK_OFFSET)
-          ? +this.getAttribute(Attributes.KEYBOARD_BACKWARD_SEEK_OFFSET)
-          : DEFAULT_SEEK_OFFSET;
-        detail = Math.max((this.mediaStore.getState().mediaCurrentTime ?? 0) - offsetValue, 0);
-        evt = new globalThis.CustomEvent(MediaUIEvents.MEDIA_SEEK_REQUEST, {
-          composed: true,
-          bubbles: true,
-          detail,
-        });
-        this.dispatchEvent(evt);
-        break;
-      }
-      case 'ArrowRight': {
-        const offsetValue = this.hasAttribute(Attributes.KEYBOARD_FORWARD_SEEK_OFFSET)
-          ? +this.getAttribute(Attributes.KEYBOARD_FORWARD_SEEK_OFFSET)
-          : DEFAULT_SEEK_OFFSET;
-        detail = Math.max((this.mediaStore.getState().mediaCurrentTime ?? 0) + offsetValue, 0);
-        evt = new globalThis.CustomEvent(MediaUIEvents.MEDIA_SEEK_REQUEST, {
-          composed: true,
-          bubbles: true,
-          detail,
-        });
-        this.dispatchEvent(evt);
-        break;
-      }
-      default:
-        break;
-    }
-  }
+			case 'ArrowLeft': {
+				const offsetValue = this.hasAttribute(
+					Attributes.KEYBOARD_BACKWARD_SEEK_OFFSET
+				)
+					? +this.getAttribute(
+							Attributes.KEYBOARD_BACKWARD_SEEK_OFFSET
+						)
+					: DEFAULT_SEEK_OFFSET;
+				detail = Math.max(
+					(this.mediaStore.getState().mediaCurrentTime ?? 0) -
+						offsetValue,
+					0
+				);
+				evt = new globalThis.CustomEvent(
+					MediaUIEvents.MEDIA_SEEK_REQUEST,
+					{
+						composed: true,
+						bubbles: true,
+						detail,
+					}
+				);
+				this.dispatchEvent(evt);
+				break;
+			}
+			case 'ArrowRight': {
+				const offsetValue = this.hasAttribute(
+					Attributes.KEYBOARD_FORWARD_SEEK_OFFSET
+				)
+					? +this.getAttribute(
+							Attributes.KEYBOARD_FORWARD_SEEK_OFFSET
+						)
+					: DEFAULT_SEEK_OFFSET;
+				detail = Math.max(
+					(this.mediaStore.getState().mediaCurrentTime ?? 0) +
+						offsetValue,
+					0
+				);
+				evt = new globalThis.CustomEvent(
+					MediaUIEvents.MEDIA_SEEK_REQUEST,
+					{
+						composed: true,
+						bubbles: true,
+						detail,
+					}
+				);
+				this.dispatchEvent(evt);
+				break;
+			}
+			default:
+				break;
+		}
+	}
 }
 
 const MEDIA_UI_ATTRIBUTE_NAMES = Object.values(MediaUIAttributes);
@@ -513,24 +613,24 @@ const MEDIA_UI_PROP_NAMES = Object.values(MediaUIProps);
  * @returns {string[]}
  */
 const getMediaUIAttributesFrom = (child) => {
-  let { observedAttributes } = child.constructor;
+	let { observedAttributes } = child.constructor;
 
-  // observedAttributes are only available if the custom element was upgraded.
-  // example: media-gesture-receiver in the shadow DOM requires an upgrade.
-  if (!observedAttributes && child.nodeName?.includes('-')) {
-    globalThis.customElements.upgrade(child);
-    ({ observedAttributes } = child.constructor);
-  }
+	// observedAttributes are only available if the custom element was upgraded.
+	// example: media-gesture-receiver in the shadow DOM requires an upgrade.
+	if (!observedAttributes && child.nodeName?.includes('-')) {
+		globalThis.customElements.upgrade(child);
+		({ observedAttributes } = child.constructor);
+	}
 
-  const mediaChromeAttributesList = child
-    ?.getAttribute?.(MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES)
-    ?.split?.(/\s+/);
+	const mediaChromeAttributesList = child
+		?.getAttribute?.(MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES)
+		?.split?.(/\s+/);
 
-  if (!Array.isArray(observedAttributes || mediaChromeAttributesList))
-    return [];
-  return (observedAttributes || mediaChromeAttributesList).filter((attrName) =>
-    MEDIA_UI_ATTRIBUTE_NAMES.includes(attrName)
-  );
+	if (!Array.isArray(observedAttributes || mediaChromeAttributesList))
+		return [];
+	return (observedAttributes || mediaChromeAttributesList).filter(
+		(attrName) => MEDIA_UI_ATTRIBUTE_NAMES.includes(attrName)
+	);
 };
 
 /**
@@ -541,14 +641,23 @@ const getMediaUIAttributesFrom = (child) => {
  * @returns {boolean}
  */
 const hasMediaUIProps = (mediaStateReceiverCandidate) => {
-  if (
-    mediaStateReceiverCandidate.nodeName?.includes('-')
-    && !!globalThis.customElements.get(mediaStateReceiverCandidate.nodeName?.toLowerCase())
-    && !(mediaStateReceiverCandidate instanceof globalThis.customElements.get(mediaStateReceiverCandidate.nodeName.toLowerCase()))
-  ) {
-    globalThis.customElements.upgrade(mediaStateReceiverCandidate);
-  }
-  return MEDIA_UI_PROP_NAMES.some(propName => propName in mediaStateReceiverCandidate);
+	if (
+		mediaStateReceiverCandidate.nodeName?.includes('-') &&
+		!!globalThis.customElements.get(
+			mediaStateReceiverCandidate.nodeName?.toLowerCase()
+		) &&
+		!(
+			mediaStateReceiverCandidate instanceof
+			globalThis.customElements.get(
+				mediaStateReceiverCandidate.nodeName.toLowerCase()
+			)
+		)
+	) {
+		globalThis.customElements.upgrade(mediaStateReceiverCandidate);
+	}
+	return MEDIA_UI_PROP_NAMES.some(
+		(propName) => propName in mediaStateReceiverCandidate
+	);
 };
 
 /**
@@ -560,47 +669,48 @@ const hasMediaUIProps = (mediaStateReceiverCandidate) => {
  */
 const isMediaStateReceiver = (child) => {
 	// TODO this is where things are going wrong.
-  return hasMediaUIProps(child) || !!getMediaUIAttributesFrom(child).length;
+	return hasMediaUIProps(child) || !!getMediaUIAttributesFrom(child).length;
 };
 
 const serializeTuple = (tuple) => tuple?.join?.(':');
 
 const CustomAttrSerializer = {
-  [MediaUIAttributes.MEDIA_SUBTITLES_LIST]: stringifyTextTrackList,
-  [MediaUIAttributes.MEDIA_SUBTITLES_SHOWING]: stringifyTextTrackList,
-  [MediaUIAttributes.MEDIA_SEEKABLE]: serializeTuple,
-  [MediaUIAttributes.MEDIA_BUFFERED]: (tuples) => tuples?.map(serializeTuple).join(' '),
-  [MediaUIAttributes.MEDIA_PREVIEW_COORDS]: (coords) => coords?.join(' '),
-  [MediaUIAttributes.MEDIA_RENDITION_LIST]: stringifyRenditionList,
-  [MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST]: stringifyAudioTrackList,
+	[MediaUIAttributes.MEDIA_SUBTITLES_LIST]: stringifyTextTrackList,
+	[MediaUIAttributes.MEDIA_SUBTITLES_SHOWING]: stringifyTextTrackList,
+	[MediaUIAttributes.MEDIA_SEEKABLE]: serializeTuple,
+	[MediaUIAttributes.MEDIA_BUFFERED]: (tuples) =>
+		tuples?.map(serializeTuple).join(' '),
+	[MediaUIAttributes.MEDIA_PREVIEW_COORDS]: (coords) => coords?.join(' '),
+	[MediaUIAttributes.MEDIA_RENDITION_LIST]: stringifyRenditionList,
+	[MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST]: stringifyAudioTrackList,
 };
 
 const setAttr = async (child, attrName, attrValue) => {
-  // If the node is not connected to the DOM yet wait on macrotask. Fix for:
-  //   Uncaught DOMException: Failed to construct 'CustomElement':
-  //   The result must not have attributes
-  if (!child.isConnected) {
-    await delay(0);
-  }
+	// If the node is not connected to the DOM yet wait on macrotask. Fix for:
+	//   Uncaught DOMException: Failed to construct 'CustomElement':
+	//   The result must not have attributes
+	if (!child.isConnected) {
+		await delay(0);
+	}
 
-  // NOTE: For "nullish" (null/undefined), can use any setter
-  if (typeof attrValue === 'boolean' || attrValue == null) {
-    return setBooleanAttr(child, attrName, attrValue);
-  }
-  if (typeof attrValue === 'number') {
-    return setNumericAttr(child, attrName, attrValue)
-  }
-  if (typeof attrValue === 'string') {
-    return setStringAttr(child, attrName, attrValue);
-  }
-  // Treat empty arrays as "nothing" values
-  if (Array.isArray(attrValue) && !attrValue.length) {
-    return child.removeAttribute(attrName);
-  }
+	// NOTE: For "nullish" (null/undefined), can use any setter
+	if (typeof attrValue === 'boolean' || attrValue == null) {
+		return setBooleanAttr(child, attrName, attrValue);
+	}
+	if (typeof attrValue === 'number') {
+		return setNumericAttr(child, attrName, attrValue);
+	}
+	if (typeof attrValue === 'string') {
+		return setStringAttr(child, attrName, attrValue);
+	}
+	// Treat empty arrays as "nothing" values
+	if (Array.isArray(attrValue) && !attrValue.length) {
+		return child.removeAttribute(attrName);
+	}
 
-  // For "special" values with custom serializers or all other values
-  const val = CustomAttrSerializer[attrName]?.(attrValue) ?? attrValue;
-  return child.setAttribute(attrName, val);
+	// For "special" values with custom serializers or all other values
+	const val = CustomAttrSerializer[attrName]?.(attrValue) ?? attrValue;
+	return child.setAttribute(attrName, val);
 };
 
 const isMediaSlotElementDescendant = (el) => !!el.closest?.('*[slot="media"]');
@@ -615,74 +725,72 @@ const isMediaSlotElementDescendant = (el) => !!el.closest?.('*[slot="media"]');
  * @param {function} mediaStateReceiverCallback
  */
 const traverseForMediaStateReceivers = (
-  rootNode,
-  mediaStateReceiverCallback
+	rootNode,
+	mediaStateReceiverCallback
 ) => {
-  // We (currently) don't check if descendants of the `media` (e.g. <video/>) are Media State Receivers
-  // See also: `propagateMediaState`
-  if (isMediaSlotElementDescendant(rootNode)) {
-    return;
-  }
-
-	console.log('traverseForMediaStateReceivers', rootNode.nodeName)
+	// We (currently) don't check if descendants of the `media` (e.g. <video/>) are Media State Receivers
+	// See also: `propagateMediaState`
+	if (isMediaSlotElementDescendant(rootNode)) {
+		return;
+	}
 
 	/**
 	 * @template {HTMLElement} T
 	 * @param {T} rootNode
 	 * @param {Function} mediaStateReceiverCallback
 	 */
-  const traverseForMediaStateReceiversSync = (
-    rootNode,
-    mediaStateReceiverCallback
-  ) => {
-    // The rootNode is itself a Media State Receiver
-    if (isMediaStateReceiver(rootNode)) {
-      mediaStateReceiverCallback(rootNode);
-    }
+	const traverseForMediaStateReceiversSync = (
+		rootNode,
+		mediaStateReceiverCallback
+	) => {
+		// The rootNode is itself a Media State Receiver
+		if (isMediaStateReceiver(rootNode)) {
+			mediaStateReceiverCallback(rootNode);
+		}
 
-		console.log('isMediaStateReceiver', rootNode.nodeName, isMediaStateReceiver(rootNode))
+		const { children = [] } = rootNode ?? {};
+		const shadowChildren = rootNode?.shadowRoot?.children ?? [];
+		const allChildren = [...children, ...shadowChildren];
 
-    const { children = [] } = rootNode ?? {};
-    const shadowChildren = rootNode?.shadowRoot?.children ?? [];
-    const allChildren = [...children, ...shadowChildren];
+		// Traverse all children (including shadowRoot children) to see if they are/have Media State Receivers
+		allChildren.forEach((child) =>
+			traverseForMediaStateReceivers(child, mediaStateReceiverCallback)
+		);
+	};
 
-    // Traverse all children (including shadowRoot children) to see if they are/have Media State Receivers
-    allChildren.forEach((child) =>
-      traverseForMediaStateReceivers(child, mediaStateReceiverCallback)
-    );
-  };
+	// Custom Elements (and *only* Custom Elements) must have a hyphen ("-") in their name. So, if the rootNode is
+	// a custom element (aka has a hyphen in its name), wait until it's defined before attempting traversal to determine
+	// whether or not it or its descendants are Media State Receivers.
+	// IMPORTANT NOTE: We're intentionally *always* waiting for the `whenDefined()` Promise to resolve here
+	// (instead of using `globalThis.customElements.get(name)` to check if a custom element is already defined/registered)
+	// because we encountered some reliability issues with the custom element instances not being fully "ready", even if/when
+	// they are available in the registry via `globalThis.customElements.get(name)`.
+	const name = rootNode?.nodeName.toLowerCase();
+	if (name.includes('-') && !isMediaStateReceiver(rootNode)) {
+		globalThis.customElements.whenDefined(name).then(() => {
+			// Try/traverse again once the custom element is defined
+			traverseForMediaStateReceiversSync(
+				rootNode,
+				mediaStateReceiverCallback
+			);
+		});
+		return;
+	}
 
-  // Custom Elements (and *only* Custom Elements) must have a hyphen ("-") in their name. So, if the rootNode is
-  // a custom element (aka has a hyphen in its name), wait until it's defined before attempting traversal to determine
-  // whether or not it or its descendants are Media State Receivers.
-  // IMPORTANT NOTE: We're intentionally *always* waiting for the `whenDefined()` Promise to resolve here
-  // (instead of using `globalThis.customElements.get(name)` to check if a custom element is already defined/registered)
-  // because we encountered some reliability issues with the custom element instances not being fully "ready", even if/when
-  // they are available in the registry via `globalThis.customElements.get(name)`.
-  const name = rootNode?.nodeName.toLowerCase();
-  if (name.includes('-') && !isMediaStateReceiver(rootNode)) {
-
-    globalThis.customElements.whenDefined(name).then(() => {
-      // Try/traverse again once the custom element is defined
-      traverseForMediaStateReceiversSync(rootNode, mediaStateReceiverCallback);
-    });
-    return;
-  }
-
-  traverseForMediaStateReceiversSync(rootNode, mediaStateReceiverCallback);
+	traverseForMediaStateReceiversSync(rootNode, mediaStateReceiverCallback);
 };
 
 const propagateMediaState = (els, stateName, val) => {
-  els.forEach((el) => {
-    if (stateName in el) {
-      el[stateName] = val;
-      return;
-    }
-    const relevantAttrs = getMediaUIAttributesFrom(el);
-    const attrName = stateName.toLowerCase();
-    if (!relevantAttrs.includes(attrName)) return;
-    setAttr(el, attrName, val);
-  });
+	els.forEach((el) => {
+		if (stateName in el) {
+			el[stateName] = val;
+			return;
+		}
+		const relevantAttrs = getMediaUIAttributesFrom(el);
+		const attrName = stateName.toLowerCase();
+		if (!relevantAttrs.includes(attrName)) return;
+		setAttr(el, attrName, val);
+	});
 };
 
 /**
@@ -698,113 +806,118 @@ const propagateMediaState = (els, stateName, val) => {
  *
  */
 const monitorForMediaStateReceivers = (
-  rootNode,
-  registerMediaStateReceiver,
-  unregisterMediaStateReceiver
+	rootNode,
+	registerMediaStateReceiver,
+	unregisterMediaStateReceiver
 ) => {
-  // First traverse the tree to register any current Media State Receivers
-  traverseForMediaStateReceivers(rootNode, registerMediaStateReceiver);
+	// First traverse the tree to register any current Media State Receivers
+	traverseForMediaStateReceivers(rootNode, registerMediaStateReceiver);
 
-  // Monitor for any event-based requests from descendants to register/unregister as a Media State Receiver
-  const registerMediaStateReceiverHandler = (evt) => {
-    const el = evt?.composedPath()[0] ?? evt.target;
-    registerMediaStateReceiver(el);
-  };
+	// Monitor for any event-based requests from descendants to register/unregister as a Media State Receiver
+	const registerMediaStateReceiverHandler = (evt) => {
+		const el = evt?.composedPath()[0] ?? evt.target;
+		registerMediaStateReceiver(el);
+	};
 
-  const unregisterMediaStateReceiverHandler = (evt) => {
-    const el = evt?.composedPath()[0] ?? evt.target;
-    unregisterMediaStateReceiver(el);
-  };
+	const unregisterMediaStateReceiverHandler = (evt) => {
+		const el = evt?.composedPath()[0] ?? evt.target;
+		unregisterMediaStateReceiver(el);
+	};
 
-  rootNode.addEventListener(
-    MediaUIEvents.REGISTER_MEDIA_STATE_RECEIVER,
-    registerMediaStateReceiverHandler
-  );
-  rootNode.addEventListener(
-    MediaUIEvents.UNREGISTER_MEDIA_STATE_RECEIVER,
-    unregisterMediaStateReceiverHandler
-  );
+	rootNode.addEventListener(
+		MediaUIEvents.REGISTER_MEDIA_STATE_RECEIVER,
+		registerMediaStateReceiverHandler
+	);
+	rootNode.addEventListener(
+		MediaUIEvents.UNREGISTER_MEDIA_STATE_RECEIVER,
+		unregisterMediaStateReceiverHandler
+	);
 
-  // Observe any changes to the DOM for any descendants that are identifiable as Media State Receivers
-  // and register or unregister them, depending on the change that occurred.
-  const mutationCallback = (mutationsList) => {
-    mutationsList.forEach((mutationRecord) => {
-			console.log('mutationRecord', mutationRecord.target?.nodeName, mutationRecord.attributeName);
-      const {
-        addedNodes = [],
-        removedNodes = [],
-        type,
-        target,
-        attributeName,
-      } = mutationRecord;
-      if (type === 'childList') {
-        // For each added node, register any Media State Receiver descendants (including itself)
-        Array.prototype.forEach.call(addedNodes, (node) =>
-          traverseForMediaStateReceivers(node, registerMediaStateReceiver)
-        );
-        // For each removed node, unregister any Media State Receiver descendants (including itself)
-        Array.prototype.forEach.call(removedNodes, (node) =>
-          traverseForMediaStateReceivers(node, unregisterMediaStateReceiver)
-        );
-      } else if (
-        type === 'attributes' &&
-        attributeName === MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES
-      ) {
-				console.log('mutationCallback', target.nodeName, isMediaStateReceiver(target))
+	// Observe any changes to the DOM for any descendants that are identifiable as Media State Receivers
+	// and register or unregister them, depending on the change that occurred.
+	const mutationCallback = (mutationsList) => {
+		mutationsList.forEach((mutationRecord) => {
+			const {
+				addedNodes = [],
+				removedNodes = [],
+				type,
+				target,
+				attributeName,
+			} = mutationRecord;
+			if (type === 'childList') {
+				// For each added node, register any Media State Receiver descendants (including itself)
+				Array.prototype.forEach.call(addedNodes, (node) =>
+					traverseForMediaStateReceivers(
+						node,
+						registerMediaStateReceiver
+					)
+				);
+				// For each removed node, unregister any Media State Receiver descendants (including itself)
+				Array.prototype.forEach.call(removedNodes, (node) =>
+					traverseForMediaStateReceivers(
+						node,
+						unregisterMediaStateReceiver
+					)
+				);
+			} else if (
+				type === 'attributes' &&
+				attributeName ===
+					MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES
+			) {
+				if (isMediaStateReceiver(target)) {
+					// Changed from a "non-Media State Receiver" to a Media State Receiver: register it.
+					registerMediaStateReceiver(target);
+				} else {
+					// Changed from a Media State Receiver to a "non-Media State Receiver": unregister it.
+					unregisterMediaStateReceiver(target);
+				}
+			}
+		});
+	};
 
-        if (isMediaStateReceiver(target)) {
-          // Changed from a "non-Media State Receiver" to a Media State Receiver: register it.
-					console.log(target.nodeName)
-          registerMediaStateReceiver(target);
-        } else {
-          // Changed from a Media State Receiver to a "non-Media State Receiver": unregister it.
-          unregisterMediaStateReceiver(target);
-        }
-      }
-    });
-  };
+	// Storing prevSlotted elements so we can cleanup if slotted elements change over time.
+	let prevSlotted = [];
+	const slotChangeHandler = (event) => {
+		const slotEl = /** @type {HTMLSlotElement} */ event.target;
+		if (slotEl.name === 'media') return;
+		prevSlotted.forEach((node) =>
+			traverseForMediaStateReceivers(node, unregisterMediaStateReceiver)
+		);
+		prevSlotted = /** @type {HTMLElement[]} */ ([
+			...slotEl.assignedElements({ flatten: true }),
+		]);
+		prevSlotted.forEach((node) =>
+			traverseForMediaStateReceivers(node, registerMediaStateReceiver)
+		);
+	};
+	rootNode.addEventListener('slotchange', slotChangeHandler);
 
-  // Storing prevSlotted elements so we can cleanup if slotted elements change over time.
-  let prevSlotted = [];
-  const slotChangeHandler = (event) => {
-    const slotEl = /** @type {HTMLSlotElement} */ event.target;
-    if (slotEl.name === "media") return;
-    prevSlotted.forEach((node) =>
-      traverseForMediaStateReceivers(node, unregisterMediaStateReceiver)
-    );
-    prevSlotted = /** @type {HTMLElement[]} */ ([...slotEl.assignedElements({ flatten: true })]);
-    prevSlotted.forEach((node) =>
-      traverseForMediaStateReceivers(node, registerMediaStateReceiver)
-    );
-  };
-  rootNode.addEventListener('slotchange', slotChangeHandler);
+	const observer = new MutationObserver(mutationCallback);
+	observer.observe(rootNode, {
+		childList: true,
+		attributes: true,
+		subtree: true,
+	});
 
-  const observer = new MutationObserver(mutationCallback);
-  observer.observe(rootNode, {
-    childList: true,
-    attributes: true,
-    subtree: true,
-  });
+	const unsubscribe = () => {
+		// Unregister any Media State Receiver descendants (including ourselves)
+		traverseForMediaStateReceivers(rootNode, unregisterMediaStateReceiver);
+		// Make sure we remove the slotchange event listener
+		rootNode.removeEventListener('slotchange', slotChangeHandler);
+		// Stop observing for Media State Receivers
+		observer.disconnect();
+		// Stop listening for Media State Receiver events.
+		rootNode.removeEventListener(
+			MediaUIEvents.REGISTER_MEDIA_STATE_RECEIVER,
+			registerMediaStateReceiverHandler
+		);
+		rootNode.removeEventListener(
+			MediaUIEvents.UNREGISTER_MEDIA_STATE_RECEIVER,
+			unregisterMediaStateReceiverHandler
+		);
+	};
 
-  const unsubscribe = () => {
-    // Unregister any Media State Receiver descendants (including ourselves)
-    traverseForMediaStateReceivers(rootNode, unregisterMediaStateReceiver);
-    // Make sure we remove the slotchange event listener
-    rootNode.removeEventListener('slotchange', slotChangeHandler);
-    // Stop observing for Media State Receivers
-    observer.disconnect();
-    // Stop listening for Media State Receiver events.
-    rootNode.removeEventListener(
-      MediaUIEvents.REGISTER_MEDIA_STATE_RECEIVER,
-      registerMediaStateReceiverHandler
-    );
-    rootNode.removeEventListener(
-      MediaUIEvents.UNREGISTER_MEDIA_STATE_RECEIVER,
-      unregisterMediaStateReceiverHandler
-    );
-  };
-
-  return unsubscribe;
+	return unsubscribe;
 };
 
 if (!globalThis.customElements.get('vinyl-controller')) {

--- a/src/web-components/vinyl-mute-button.js
+++ b/src/web-components/vinyl-mute-button.js
@@ -1,0 +1,59 @@
+import { MediaMuteButton } from 'media-chrome';
+import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
+
+import labels from '../labels/index.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+
+/**
+ * @param {VinylMuteButton} el
+ */
+const updateAriaLabel = (el) => {
+	const muted = el.mediaVolumeLevel === 'off';
+	const label = muted ? labels.verbs.UNMUTE() : labels.verbs.MUTE();
+	el.setAttribute('aria-label', label);
+};
+
+/**
+ * @slot off - An element shown when the media is muted or the media’s volume is 0.
+ * @slot low - An element shown when the media’s volume is “low” (less than 50% / 0.5).
+ * @slot medium - An element shown when the media’s volume is “medium” (between 50% / 0.5 and 75% / 0.75).
+ * @slot high - An element shown when the media’s volume is “high” (75% / 0.75 or greater).
+ * @slot icon - An element for representing all states in a single icon
+ *
+ * @attr {string} mediavolumelevel - (read-only) Set to the media volume level.
+ *
+ * @cssproperty [--media-mute-button-display = inline-flex] - `display` property of button.
+ */
+class VinylMuteButton extends MediaMuteButton {
+	static get observedAttributes() {
+		return [
+			...super.observedAttributes,
+			MediaUIAttributes.MEDIA_VOLUME_LEVEL,
+		];
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		updateAriaLabel(this);
+	}
+
+	/**
+	 * @param {string} attrName
+	 * @param {any}    oldValue
+	 * @param {any}    newValue
+	 */
+	attributeChangedCallback(attrName, oldValue, newValue) {
+		if (attrName === MediaUIAttributes.MEDIA_VOLUME_LEVEL) {
+			updateAriaLabel(this);
+		}
+
+		super.attributeChangedCallback(attrName, oldValue, newValue);
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-mute-button')) {
+	globalThis.customElements.define('vinyl-mute-button', VinylMuteButton);
+}
+
+export { VinylMuteButton };
+export default VinylMuteButton;

--- a/src/web-components/vinyl-mute-button.js
+++ b/src/web-components/vinyl-mute-button.js
@@ -25,13 +25,6 @@ const updateAriaLabel = (el) => {
  * @cssproperty [--media-mute-button-display = inline-flex] - `display` property of button.
  */
 class VinylMuteButton extends MediaMuteButton {
-	static get observedAttributes() {
-		return [
-			...super.observedAttributes,
-			MediaUIAttributes.MEDIA_VOLUME_LEVEL,
-		];
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 		updateAriaLabel(this);

--- a/src/web-components/vinyl-play-button.js
+++ b/src/web-components/vinyl-play-button.js
@@ -1,0 +1,57 @@
+import { MediaPlayButton } from 'media-chrome';
+import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
+
+import labels from '../labels/index.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+
+/**
+ * @param {VinylPlayButton} el
+ */
+const updateAriaLabel = (el) => {
+	const label = el.mediaPaused ? labels.verbs.PLAY() : labels.verbs.PAUSE();
+	el.setAttribute('aria-label', label);
+};
+
+/**
+ * @slot play - An element shown when the media is paused and pressing the button will start media playback.
+ * @slot pause - An element shown when the media is playing and pressing the button will pause media playback.
+ * @slot icon - An element for representing play and pause states in a single icon
+ *
+ * @attr {boolean} mediapaused - (read-only) Present if the media is paused.
+ *
+ * @cssproperty [--media-play-button-display = inline-flex] - `display` property of button.
+ */
+class VinylPlayButton extends MediaPlayButton {
+	static get observedAttributes() {
+		return [
+			...super.observedAttributes,
+			MediaUIAttributes.MEDIA_PAUSED,
+			MediaUIAttributes.MEDIA_ENDED,
+		];
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		updateAriaLabel(this);
+	}
+
+	/**
+	 * @param {string} attrName
+	 * @param {any}    oldValue
+	 * @param {any}    newValue
+	 */
+	attributeChangedCallback(attrName, oldValue, newValue) {
+		if (attrName === MediaUIAttributes.MEDIA_PAUSED) {
+			updateAriaLabel(this);
+		}
+
+		super.attributeChangedCallback(attrName, oldValue, newValue);
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-play-button')) {
+	globalThis.customElements.define('vinyl-play-button', VinylPlayButton);
+}
+
+export { VinylPlayButton };
+export default VinylPlayButton;

--- a/src/web-components/vinyl-play-button.js
+++ b/src/web-components/vinyl-play-button.js
@@ -22,14 +22,6 @@ const updateAriaLabel = (el) => {
  * @cssproperty [--media-play-button-display = inline-flex] - `display` property of button.
  */
 class VinylPlayButton extends MediaPlayButton {
-	static get observedAttributes() {
-		return [
-			...super.observedAttributes,
-			MediaUIAttributes.MEDIA_PAUSED,
-			MediaUIAttributes.MEDIA_ENDED,
-		];
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 		updateAriaLabel(this);

--- a/src/web-components/vinyl-playback-rate-button.js
+++ b/src/web-components/vinyl-playback-rate-button.js
@@ -1,0 +1,125 @@
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	MediaUIEvents,
+	MediaUIAttributes,
+} from 'media-chrome/dist/constants.js';
+import {
+	default as MediaPlaybackRateButton,
+	Attributes,
+} from 'media-chrome/dist/media-playback-rate-button.js';
+import { AttributeTokenList } from 'media-chrome/dist/utils/attribute-token-list.js';
+
+import labels from '../labels/index.js';
+import { document, globalThis } from '../utils/server-safe-globals.js';
+
+export const DEFAULT_RATES = [1, 1.2, 1.5, 1.7, 2];
+export const DEFAULT_RATE = 1;
+
+const slotTemplate = document.createElement('template');
+slotTemplate.innerHTML = /*html*/ `
+  <style>
+    :host {
+      min-width: 5ch;
+      padding: var(--media-button-padding, var(--media-control-padding, 10px 5px));
+    }
+  </style>
+  <slot name="icon"></slot>
+`;
+
+/**
+ * @attr {string} rates - Set custom playback rates for the user to choose from.
+ * @attr {string} mediaplaybackrate - (read-only) Set to the media playback rate.
+ *
+ * @cssproperty [--media-playback-rate-button-display = inline-flex] - `display` property of button.
+ */
+class VinylPlaybackRateButton extends MediaPlaybackRateButton {
+	static get observedAttributes() {
+		return [
+			...super.observedAttributes,
+			MediaUIAttributes.MEDIA_PLAYBACK_RATE,
+			Attributes.RATES,
+		];
+	}
+
+	/** @type {AttributeTokenList} */
+	#rates = new AttributeTokenList(this, Attributes.RATES, {
+		defaultValue: DEFAULT_RATES,
+	});
+
+	constructor(options = {}) {
+		super({ slotTemplate, ...options });
+		/** @type {HTMLElement} */
+		// @ts-expect-error: The `shadowRoot` property is set by the parent class.
+		this.container = this.shadowRoot.querySelector('slot[name="icon"]');
+		this.container.innerHTML = sprintf(
+			/* translators: playback rate with multiplication symbol */
+			__('%sx', 'vinyl'),
+			DEFAULT_RATE
+		);
+	}
+
+	attributeChangedCallback(attrName, oldValue, newValue) {
+		super.attributeChangedCallback(attrName, oldValue, newValue);
+
+		if (attrName === Attributes.RATES) {
+			this.#rates.value = newValue;
+		}
+		if (attrName === MediaUIAttributes.MEDIA_PLAYBACK_RATE) {
+			const newPlaybackRate = newValue ? +newValue : Number.NaN;
+			const playbackRate = !Number.isNaN(newPlaybackRate)
+				? newPlaybackRate
+				: DEFAULT_RATE;
+			this.container.innerHTML = sprintf(
+				/* translators: playback rate with multiplication symbol */
+				__('%sx', 'vinyl'),
+				playbackRate
+			);
+			this.setAttribute(
+				'aria-label',
+				labels.nouns.PLAYBACK_RATE({ playbackRate })
+			);
+		}
+	}
+
+	/**
+	 * @type { AttributeTokenList | Array<number>} Will return a DOMTokenList.
+	 * Setting a value will accept an array of numbers.
+	 */
+	get rates() {
+		return this.#rates;
+	}
+
+	set rates(value) {
+		if (!value) {
+			this.#rates.value = '';
+		} else if (Array.isArray(value)) {
+			this.#rates.value = value.join(' ');
+		}
+	}
+
+	handleClick() {
+		const availableRates = Array.from(
+			this.#rates.values(),
+			(str) => +str
+		).sort((a, b) => a - b);
+
+		const detail =
+			availableRates.find((r) => r > this.mediaPlaybackRate) ??
+			availableRates[0] ??
+			DEFAULT_RATE;
+		const evt = new globalThis.CustomEvent(
+			MediaUIEvents.MEDIA_PLAYBACK_RATE_REQUEST,
+			{ composed: true, bubbles: true, detail }
+		);
+		this.dispatchEvent(evt);
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-playback-rate-button')) {
+	globalThis.customElements.define(
+		'vinyl-playback-rate-button',
+		VinylPlaybackRateButton
+	);
+}
+
+export default VinylPlaybackRateButton;

--- a/src/web-components/vinyl-seek-backward-button.js
+++ b/src/web-components/vinyl-seek-backward-button.js
@@ -1,0 +1,146 @@
+import { MediaChromeButton } from 'media-chrome';
+import {
+	MediaUIEvents,
+	MediaUIAttributes,
+} from 'media-chrome/dist/constants.js';
+
+import labels from '../labels/index.js';
+import {
+	getNumericAttr,
+	setNumericAttr,
+	getSlotted,
+	updateIconText,
+} from '../utils/element-utils.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+
+export const Attributes = {
+	SEEK_OFFSET: 'seekoffset',
+};
+
+const DEFAULT_SEEK_OFFSET = 30;
+
+const backwardIcon = `<svg aria-hidden="true" viewBox="0 0 20 24"><defs><style>.text{font-size:8px;font-family:Arial-BoldMT, Arial;font-weight:700;}</style></defs><text class="text value" transform="translate(2.18 19.87)">${DEFAULT_SEEK_OFFSET}</text><path d="M10 6V3L4.37 7 10 10.94V8a5.54 5.54 0 0 1 1.9 10.48v2.12A7.5 7.5 0 0 0 10 6Z"/></svg>`;
+
+const slotTemplate = document.createElement('template');
+slotTemplate.innerHTML = `
+  <slot name="icon">${backwardIcon}</slot>
+`;
+
+const DEFAULT_TIME = 0;
+
+/**
+ * @slot icon - The element shown for the seek backward button’s display.
+ *
+ * @attr {string} seekoffset - Adjusts how much time (in seconds) the playhead should seek backward.
+ * @attr {string} mediacurrenttime - (read-only) Set to the current media time.
+ *
+ * @cssproperty [--media-seek-backward-button-display = inline-flex] - `display` property of button.
+ */
+class VinylSeekBackwardButton extends MediaChromeButton {
+	static get observedAttributes() {
+		return [
+			...super.observedAttributes,
+			MediaUIAttributes.MEDIA_CURRENT_TIME,
+			Attributes.SEEK_OFFSET,
+		];
+	}
+
+	constructor(options = {}) {
+		super({ slotTemplate, ...options });
+	}
+
+	connectedCallback() {
+		this.seekOffset = getNumericAttr(
+			this,
+			Attributes.SEEK_OFFSET,
+			DEFAULT_SEEK_OFFSET
+		);
+		super.connectedCallback();
+	}
+
+	attributeChangedCallback(attrName, _oldValue, newValue) {
+		if (attrName === Attributes.SEEK_OFFSET) {
+			this.seekOffset = getNumericAttr(
+				this,
+				Attributes.SEEK_OFFSET,
+				DEFAULT_SEEK_OFFSET
+			);
+		}
+
+		super.attributeChangedCallback(attrName, _oldValue, newValue);
+	}
+
+	// Own props
+
+	/**
+	 * @type {number | undefined} Seek amount in seconds
+	 */
+	get seekOffset() {
+		return getNumericAttr(
+			this,
+			Attributes.SEEK_OFFSET,
+			DEFAULT_SEEK_OFFSET
+		);
+	}
+
+	/**
+	 * @param {number | undefined} value
+	 */
+	set seekOffset(value) {
+		setNumericAttr(this, Attributes.SEEK_OFFSET, value);
+		this.setAttribute(
+			'aria-label',
+			labels.verbs.SEEK_BACK_N_SECS({ seekOffset: this.seekOffset })
+		);
+		updateIconText(
+			getSlotted(this, 'icon'),
+			typeof this.seekOffset === 'number'
+				? this.seekOffset.toString()
+				: ''
+		);
+	}
+
+	// Props derived from Media UI Attributes
+
+	/**
+	 * The current time
+	 * @type {number | undefined} In seconds
+	 */
+	get mediaCurrentTime() {
+		return getNumericAttr(
+			this,
+			MediaUIAttributes.MEDIA_CURRENT_TIME,
+			DEFAULT_TIME
+		);
+	}
+
+	/**
+	 * @param {number | undefined} time
+	 */
+	set mediaCurrentTime(time) {
+		setNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME, time);
+	}
+
+	handleClick() {
+		if (!this.mediaCurrentTime || !this.seekOffset) return;
+		const detail = Math.max(this.mediaCurrentTime - this.seekOffset, 0);
+		const evt = new globalThis.CustomEvent(
+			MediaUIEvents.MEDIA_SEEK_REQUEST,
+			{
+				composed: true,
+				bubbles: true,
+				detail,
+			}
+		);
+		this.dispatchEvent(evt);
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-seek-backward-button')) {
+	globalThis.customElements.define(
+		'vinyl-seek-backward-button',
+		VinylSeekBackwardButton
+	);
+}
+
+export default VinylSeekBackwardButton;

--- a/src/web-components/vinyl-seek-forward-button.js
+++ b/src/web-components/vinyl-seek-forward-button.js
@@ -1,0 +1,147 @@
+import { MediaChromeButton } from 'media-chrome';
+import {
+	MediaUIEvents,
+	MediaUIAttributes,
+} from 'media-chrome/dist/constants.js';
+
+import labels from '../labels/index.js';
+import {
+	getNumericAttr,
+	setNumericAttr,
+	getSlotted,
+	updateIconText,
+} from '../utils/element-utils.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+
+export const Attributes = {
+	SEEK_OFFSET: 'seekoffset',
+};
+
+const DEFAULT_SEEK_OFFSET = 30;
+
+const forwardIcon = `<svg aria-hidden="true" viewBox="0 0 20 24"><defs><style>.text{font-size:8px;font-family:Arial-BoldMT, Arial;font-weight:700;}</style></defs><text class="text value" transform="translate(8.9 19.87)">${DEFAULT_SEEK_OFFSET}</text><path d="M10 6V3l5.61 4L10 10.94V8a5.54 5.54 0 0 0-1.9 10.48v2.12A7.5 7.5 0 0 1 10 6Z"/></svg>`;
+
+const slotTemplate = document.createElement('template');
+slotTemplate.innerHTML = `
+  <slot name="icon">${forwardIcon}</slot>
+`;
+
+const DEFAULT_TIME = 0;
+
+/**
+ * @slot icon - The element shown for the seek forward button’s display.
+ *
+ * @attr {string} seekoffset - Adjusts how much time (in seconds) the playhead should seek forward.
+ * @attr {string} mediacurrenttime - (read-only) Set to the current media time.
+ *
+ * @cssproperty [--media-seek-forward-button-display = inline-flex] - `display` property of button.
+ */
+class VinylSeekForwardButton extends MediaChromeButton {
+	static get observedAttributes() {
+		return [
+			...super.observedAttributes,
+			MediaUIAttributes.MEDIA_CURRENT_TIME,
+			Attributes.SEEK_OFFSET,
+		];
+	}
+
+	constructor(options = {}) {
+		super({ slotTemplate, ...options });
+	}
+
+	connectedCallback() {
+		this.seekOffset = getNumericAttr(
+			this,
+			Attributes.SEEK_OFFSET,
+			DEFAULT_SEEK_OFFSET
+		);
+		super.connectedCallback();
+	}
+
+	attributeChangedCallback(attrName, _oldValue, newValue) {
+		if (attrName === Attributes.SEEK_OFFSET) {
+			this.seekOffset = getNumericAttr(
+				this,
+				Attributes.SEEK_OFFSET,
+				DEFAULT_SEEK_OFFSET
+			);
+		}
+
+		super.attributeChangedCallback(attrName, _oldValue, newValue);
+	}
+
+	// Own props
+
+	/**
+	 * @type {number | undefined} Seek amount in seconds
+	 */
+	get seekOffset() {
+		return getNumericAttr(
+			this,
+			Attributes.SEEK_OFFSET,
+			DEFAULT_SEEK_OFFSET
+		);
+	}
+
+	/**
+	 * @param {number | undefined} value
+	 */
+	set seekOffset(value) {
+		setNumericAttr(this, Attributes.SEEK_OFFSET, value);
+		this.setAttribute(
+			'aria-label',
+			labels.verbs.SEEK_FORWARD_N_SECS({ seekOffset: this.seekOffset })
+		);
+		updateIconText(
+			getSlotted(this, 'icon'),
+			typeof this.seekOffset === 'number'
+				? this.seekOffset.toString()
+				: ''
+		);
+	}
+
+	// Props derived from Media UI Attributes
+
+	/**
+	 * The current time
+	 *
+	 * @type {number | undefined} In seconds
+	 */
+	get mediaCurrentTime() {
+		return getNumericAttr(
+			this,
+			MediaUIAttributes.MEDIA_CURRENT_TIME,
+			DEFAULT_TIME
+		);
+	}
+
+	/**
+	 * @param {number | undefined} time
+	 */
+	set mediaCurrentTime(time) {
+		setNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME, time);
+	}
+
+	handleClick() {
+		if (!this.mediaCurrentTime || !this.seekOffset) return;
+		const detail = this.mediaCurrentTime + this.seekOffset;
+		const evt = new globalThis.CustomEvent(
+			MediaUIEvents.MEDIA_SEEK_REQUEST,
+			{
+				composed: true,
+				bubbles: true,
+				detail,
+			}
+		);
+		this.dispatchEvent(evt);
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-seek-forward-button')) {
+	globalThis.customElements.define(
+		'vinyl-seek-forward-button',
+		VinylSeekForwardButton
+	);
+}
+
+export default VinylSeekForwardButton;

--- a/src/web-components/vinyl-time-display.js
+++ b/src/web-components/vinyl-time-display.js
@@ -1,5 +1,4 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
 import {
 	default as MediaTimeDisplay,
 	Attributes,
@@ -12,13 +11,6 @@ import { formatAsTimePhrase, formatTime } from '../utils/time.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 const DEFAULT_TIMES_SEP = '&nbsp;/&nbsp;';
-
-const CombinedAttributes = [
-	...Object.values(Attributes),
-	MediaUIAttributes.MEDIA_CURRENT_TIME,
-	MediaUIAttributes.MEDIA_DURATION,
-	MediaUIAttributes.MEDIA_SEEKABLE,
-];
 
 /**
  * @param {VinylTimeDisplay} el
@@ -103,10 +95,6 @@ const updateAriaValueText = (el) => {
  * @cssproperty --media-control-hover-background - `background` of control hover state.
  */
 class VinylTimeDisplay extends MediaTimeDisplay {
-	static get observedAttributes() {
-		return [...super.observedAttributes, ...CombinedAttributes, 'disabled'];
-	}
-
 	/** @type {HTMLSlotElement} */
 	#slot;
 

--- a/src/web-components/vinyl-time-display.js
+++ b/src/web-components/vinyl-time-display.js
@@ -1,0 +1,141 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
+import {
+	default as MediaTimeDisplay,
+	Attributes,
+} from 'media-chrome/dist/media-time-display.js';
+
+import labels from '../labels/index.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+import { formatAsTimePhrase, formatTime } from '../utils/time.js';
+
+// Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
+
+const DEFAULT_TIMES_SEP = '&nbsp;/&nbsp;';
+
+const CombinedAttributes = [
+	...Object.values(Attributes),
+	MediaUIAttributes.MEDIA_CURRENT_TIME,
+	MediaUIAttributes.MEDIA_DURATION,
+	MediaUIAttributes.MEDIA_SEEKABLE,
+];
+
+/**
+ * @param {VinylTimeDisplay} el
+ * @param {Object}           options
+ * @param {string}           [options.timesSep]
+ */
+const formatTimesLabel = (el, { timesSep = DEFAULT_TIMES_SEP } = {}) => {
+	const showRemaining = el.hasAttribute(Attributes.REMAINING);
+	const showDuration = el.hasAttribute(Attributes.SHOW_DURATION);
+	const currentTime = el.mediaCurrentTime ?? 0;
+	const [, seekableEnd] = el.mediaSeekable ?? [];
+	let endTime = 0;
+
+	if (Number.isFinite(el.mediaDuration)) {
+		endTime = el.mediaDuration;
+	} else if (Number.isFinite(seekableEnd)) {
+		endTime = seekableEnd;
+	}
+
+	const timeLabel = showRemaining
+		? formatTime(0 - (endTime - currentTime))
+		: formatTime(currentTime);
+
+	if (!showDuration) return timeLabel;
+	return `${timeLabel}${timesSep}${formatTime(endTime)}`;
+};
+
+const DEFAULT_MISSING_TIME_PHRASE = __(
+	'Media not loaded, unknown time.',
+	'vinyl'
+);
+
+const updateAriaValueText = (el) => {
+	const currentTime = el.mediaCurrentTime;
+	const [, seekableEnd] = el.mediaSeekable ?? [];
+	let endTime = null;
+
+	if (Number.isFinite(el.mediaDuration)) {
+		endTime = el.mediaDuration;
+	} else if (Number.isFinite(seekableEnd)) {
+		endTime = seekableEnd;
+	}
+
+	if (currentTime === null || endTime === null) {
+		el.setAttribute('aria-valuetext', DEFAULT_MISSING_TIME_PHRASE);
+		return;
+	}
+
+	const showRemaining = el.hasAttribute(Attributes.REMAINING);
+	const showDuration = el.hasAttribute(Attributes.SHOW_DURATION);
+
+	const currentTimePhrase = showRemaining
+		? formatAsTimePhrase(0 - (endTime - currentTime))
+		: formatAsTimePhrase(currentTime);
+
+	if (!showDuration) {
+		el.setAttribute('aria-valuetext', currentTimePhrase);
+		return;
+	}
+
+	const totalTimePhrase = formatAsTimePhrase(endTime);
+	const fullPhrase = sprintf(
+		/* translators: 1: current time, 2: total time */
+		__('%1$s of %2$s', 'vinyl'),
+		currentTimePhrase,
+		totalTimePhrase
+	);
+
+	el.setAttribute('aria-valuetext', fullPhrase);
+};
+
+/**
+ * @attr {boolean} remaining - Toggle on to show the remaining time instead of elapsed time.
+ * @attr {boolean} showduration - Toggle on to show the duration.
+ * @attr {boolean} disabled - The Boolean disabled attribute makes the element not mutable or focusable.
+ * @attr {boolean} notoggle - Set this to disable click or tap behavior that toggles between remaining and current time.
+ * @attr {string} mediacurrenttime - (read-only) Set to the current media time.
+ * @attr {string} mediaduration - (read-only) Set to the media duration.
+ * @attr {string} mediaseekable - (read-only) Set to the seekable time ranges.
+ *
+ * @cssproperty [--media-time-display-display = inline-flex] - `display` property of display.
+ * @cssproperty --media-control-hover-background - `background` of control hover state.
+ */
+class VinylTimeDisplay extends MediaTimeDisplay {
+	static get observedAttributes() {
+		return [...super.observedAttributes, ...CombinedAttributes, 'disabled'];
+	}
+
+	/** @type {HTMLSlotElement} */
+	#slot;
+
+	constructor() {
+		super();
+
+		this.#slot = this.shadowRoot.querySelector('slot');
+		this.#slot.innerHTML = `${formatTimesLabel(this)}`;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.setAttribute('aria-label', labels.nouns.PLAYBACK_TIME());
+	}
+
+	update() {
+		const timesLabel = formatTimesLabel(this);
+
+		updateAriaValueText(this);
+
+		// Only update if it changed, timeupdate events are called a few times per second.
+		if (timesLabel !== this.#slot.innerHTML) {
+			this.#slot.innerHTML = timesLabel;
+		}
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-time-display')) {
+	globalThis.customElements.define('vinyl-time-display', VinylTimeDisplay);
+}
+
+export default VinylTimeDisplay;

--- a/src/web-components/vinyl-time-range.js
+++ b/src/web-components/vinyl-time-range.js
@@ -1,5 +1,4 @@
 import { MediaTimeRange } from 'media-chrome';
-import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
 
 import labels from '../labels/index.js';
 import { globalThis } from '../utils/server-safe-globals.js';
@@ -73,23 +72,6 @@ import { globalThis } from '../utils/server-safe-globals.js';
  * @cssproperty --media-box-arrow-offset - `translateX` offset of range box arrow.
  */
 class VinylTimeRange extends MediaTimeRange {
-	static get observedAttributes() {
-		return [
-			...super.observedAttributes,
-			MediaUIAttributes.MEDIA_PAUSED,
-			MediaUIAttributes.MEDIA_DURATION,
-			MediaUIAttributes.MEDIA_SEEKABLE,
-			MediaUIAttributes.MEDIA_CURRENT_TIME,
-			MediaUIAttributes.MEDIA_PREVIEW_IMAGE,
-			MediaUIAttributes.MEDIA_PREVIEW_TIME,
-			MediaUIAttributes.MEDIA_PREVIEW_CHAPTER,
-			MediaUIAttributes.MEDIA_BUFFERED,
-			MediaUIAttributes.MEDIA_PLAYBACK_RATE,
-			MediaUIAttributes.MEDIA_LOADING,
-			MediaUIAttributes.MEDIA_ENDED,
-		];
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 		this.range.setAttribute('aria-label', labels.nouns.SEEK());

--- a/src/web-components/vinyl-time-range.js
+++ b/src/web-components/vinyl-time-range.js
@@ -1,0 +1,103 @@
+import { MediaTimeRange } from 'media-chrome';
+import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
+
+import labels from '../labels/index.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+
+/**
+ * @slot preview - An element that slides along the timeline to the position of the pointer hovering.
+ * @slot preview-arrow - An arrow element that slides along the timeline to the position of the pointer hovering.
+ * @slot current - An element that slides along the timeline to the position of the current time.
+ *
+ * @attr {string} mediabuffered - (read-only) Set to the buffered time ranges.
+ * @attr {string} mediaplaybackrate - (read-only) Set to the media playback rate.
+ * @attr {string} mediaduration - (read-only) Set to the media duration.
+ * @attr {string} mediaseekable - (read-only) Set to the seekable time ranges.
+ * @attr {boolean} mediapaused - (read-only) Present if the media is paused.
+ * @attr {boolean} medialoading - (read-only) Present if the media is loading.
+ * @attr {string} mediacurrenttime - (read-only) Set to the current media time.
+ * @attr {string} mediapreviewimage - (read-only) Set to the timeline preview image URL.
+ * @attr {string} mediapreviewtime - (read-only) Set to the timeline preview time.
+ *
+ * @csspart box - A CSS part that selects both the preview and current box elements.
+ * @csspart preview-box - A CSS part that selects the preview box element.
+ * @csspart current-box - A CSS part that selects the current box element.
+ * @csspart arrow - A CSS part that selects the arrow element.
+ *
+ * @cssproperty [--media-time-range-display = inline-block] - `display` property of range.
+ *
+ * @cssproperty --media-preview-transition-property - `transition-property` of range hover preview.
+ * @cssproperty --media-preview-transition-duration-out - `transition-duration` out of range hover preview.
+ * @cssproperty --media-preview-transition-delay-out - `transition-delay` out of range hover preview.
+ * @cssproperty --media-preview-transition-duration-in - `transition-duration` in of range hover preview.
+ * @cssproperty --media-preview-transition-delay-in - `transition-delay` in of range hover preview.
+ *
+ * @cssproperty --media-preview-thumbnail-background - `background` of range preview thumbnail.
+ * @cssproperty --media-preview-thumbnail-box-shadow - `box-shadow` of range preview thumbnail.
+ * @cssproperty --media-preview-thumbnail-max-width - `max-width` of range preview thumbnail.
+ * @cssproperty --media-preview-thumbnail-max-height - `max-height` of range preview thumbnail.
+ * @cssproperty --media-preview-thumbnail-min-width - `min-width` of range preview thumbnail.
+ * @cssproperty --media-preview-thumbnail-min-height - `min-height` of range preview thumbnail.
+ * @cssproperty --media-preview-thumbnail-border-radius - `border-radius` of range preview thumbnail.
+ * @cssproperty --media-preview-thumbnail-border - `border` of range preview thumbnail.
+ *
+ * @cssproperty --media-preview-chapter-background - `background` of range preview chapter display.
+ * @cssproperty --media-preview-chapter-border-radius - `border-radius` of range preview chapter display.
+ * @cssproperty --media-preview-chapter-padding - `padding` of range preview chapter display.
+ * @cssproperty --media-preview-chapter-margin - `margin` of range preview chapter display.
+ * @cssproperty --media-preview-chapter-text-shadow - `text-shadow` of range preview chapter display.
+ *
+ * @cssproperty --media-preview-time-background - `background` of range preview time display.
+ * @cssproperty --media-preview-time-border-radius - `border-radius` of range preview time display.
+ * @cssproperty --media-preview-time-padding - `padding` of range preview time display.
+ * @cssproperty --media-preview-time-margin - `margin` of range preview time display.
+ * @cssproperty --media-preview-time-text-shadow - `text-shadow` of range preview time display.
+ *
+ * @cssproperty --media-box-display - `display` of range box.
+ * @cssproperty --media-box-margin - `margin` of range box.
+ * @cssproperty --media-box-padding-left - `padding-left` of range box.
+ * @cssproperty --media-box-padding-right - `padding-right` of range box.
+ * @cssproperty --media-box-border-radius - `border-radius` of range box.
+ *
+ * @cssproperty --media-preview-box-display - `display` of range preview box.
+ * @cssproperty --media-preview-box-margin - `margin` of range preview box.
+ *
+ * @cssproperty --media-current-box-display - `display` of range current box.
+ * @cssproperty --media-current-box-margin - `margin` of range current box.
+ *
+ * @cssproperty --media-box-arrow-display - `display` of range box arrow.
+ * @cssproperty --media-box-arrow-background - `border-top-color` of range box arrow.
+ * @cssproperty --media-box-arrow-border-width - `border-width` of range box arrow.
+ * @cssproperty --media-box-arrow-height - `height` of range box arrow.
+ * @cssproperty --media-box-arrow-width - `width` of range box arrow.
+ * @cssproperty --media-box-arrow-offset - `translateX` offset of range box arrow.
+ */
+class VinylTimeRange extends MediaTimeRange {
+	static get observedAttributes() {
+		return [
+			...super.observedAttributes,
+			MediaUIAttributes.MEDIA_PAUSED,
+			MediaUIAttributes.MEDIA_DURATION,
+			MediaUIAttributes.MEDIA_SEEKABLE,
+			MediaUIAttributes.MEDIA_CURRENT_TIME,
+			MediaUIAttributes.MEDIA_PREVIEW_IMAGE,
+			MediaUIAttributes.MEDIA_PREVIEW_TIME,
+			MediaUIAttributes.MEDIA_PREVIEW_CHAPTER,
+			MediaUIAttributes.MEDIA_BUFFERED,
+			MediaUIAttributes.MEDIA_PLAYBACK_RATE,
+			MediaUIAttributes.MEDIA_LOADING,
+			MediaUIAttributes.MEDIA_ENDED,
+		];
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.range.setAttribute('aria-label', labels.nouns.SEEK());
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-time-range')) {
+	globalThis.customElements.define('vinyl-time-range', VinylTimeRange);
+}
+
+export default VinylTimeRange;

--- a/src/web-components/vinyl-volume-range.js
+++ b/src/web-components/vinyl-volume-range.js
@@ -19,15 +19,6 @@ const formatAsPercentString = ({ value }) => `${Math.round(value * 100)}%`;
  * @cssproperty [--media-volume-range-display = inline-block] - `display` property of range.
  */
 class VinylVolumeRange extends MediaVolumeRange {
-	static get observedAttributes() {
-		return [
-			...super.observedAttributes,
-			MediaUIAttributes.MEDIA_VOLUME,
-			MediaUIAttributes.MEDIA_MUTED,
-			MediaUIAttributes.MEDIA_VOLUME_UNAVAILABLE,
-		];
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 		this.range.setAttribute('aria-label', labels.nouns.VOLUME());

--- a/src/web-components/vinyl-volume-range.js
+++ b/src/web-components/vinyl-volume-range.js
@@ -1,0 +1,62 @@
+import { MediaVolumeRange } from 'media-chrome';
+import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
+
+import labels from '../labels/index.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+
+const toVolume = (el) => {
+	if (el.mediaMuted) return 0;
+	return el.mediaVolume;
+};
+
+const formatAsPercentString = ({ value }) => `${Math.round(value * 100)}%`;
+
+/**
+ * @attr {string} mediavolume - (read-only) Set to the media volume.
+ * @attr {boolean} mediamuted - (read-only) Set to the media muted state.
+ * @attr {string} mediavolumeunavailable - (read-only) Set if changing volume is unavailable.
+ *
+ * @cssproperty [--media-volume-range-display = inline-block] - `display` property of range.
+ */
+class VinylVolumeRange extends MediaVolumeRange {
+	static get observedAttributes() {
+		return [
+			...super.observedAttributes,
+			MediaUIAttributes.MEDIA_VOLUME,
+			MediaUIAttributes.MEDIA_MUTED,
+			MediaUIAttributes.MEDIA_VOLUME_UNAVAILABLE,
+		];
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.range.setAttribute('aria-label', labels.nouns.VOLUME());
+	}
+
+	/**
+	 * @param {string} attrName
+	 * @param {any}    oldValue
+	 * @param {any}    newValue
+	 */
+	attributeChangedCallback(attrName, oldValue, newValue) {
+		super.attributeChangedCallback(attrName, oldValue, newValue);
+
+		if (
+			attrName === MediaUIAttributes.MEDIA_VOLUME ||
+			attrName === MediaUIAttributes.MEDIA_MUTED
+		) {
+			this.range.valueAsNumber = toVolume(this);
+			this.range.setAttribute(
+				'aria-valuetext',
+				formatAsPercentString(this.range)
+			);
+			this.updateBar();
+		}
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-volume-range')) {
+	globalThis.customElements.define('vinyl-volume-range', VinylVolumeRange);
+}
+
+export default VinylVolumeRange;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,5 +4,11 @@
 		"noEmit": true,
 		"allowJs": true
 	},
-	"include": [".eslintrc.cjs", ".prettierrc.cjs", "lint-staged.config.cjs", "webpack.config.cjs"]
+	"include": [
+		"bin/react/**/*",
+		".eslintrc.cjs",
+		".prettierrc.cjs",
+		"lint-staged.config.cjs",
+		"webpack.config.cjs"
+	]
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,16 +1,31 @@
-const path = require('path');
+const path = require('node:path');
 
 const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+// const webpack = require('webpack');
 
 module.exports = {
 	...defaultConfig,
 	entry: {
 		...defaultConfig.entry(),
-		'media-chrome': path.resolve(
-			process.cwd(),
-			'src',
-			'audio',
-			'media-chrome'
-		),
+		'media-chrome': path.resolve(process.cwd(), 'src', 'media-chrome'),
 	},
+	resolve: {
+		...defaultConfig.resolve,
+		extensionAlias: {
+			'.js': ['.ts', '.tsx', '.js', '.jsx'],
+			'.mjs': ['.mts', '.mjs'],
+		},
+	},
+	// plugins: [
+	// 	...defaultConfig.plugins,
+	// 	new webpack.NormalModuleReplacementPlugin(
+	// 		new RegExp(/^\..+\.js$/),
+	// 		function (resource) {
+	// 			resource.request = resource.request.replace(
+	// 				new RegExp(/\.js$/),
+	// 				''
+	// 			);
+	// 		}
+	// 	),
+	// ],
 };

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,7 +1,6 @@
 const path = require('node:path');
 
 const defaultConfig = require('@wordpress/scripts/config/webpack.config');
-// const webpack = require('webpack');
 
 module.exports = {
 	...defaultConfig,
@@ -16,16 +15,4 @@ module.exports = {
 			'.mjs': ['.mts', '.mjs'],
 		},
 	},
-	// plugins: [
-	// 	...defaultConfig.plugins,
-	// 	new webpack.NormalModuleReplacementPlugin(
-	// 		new RegExp(/^\..+\.js$/),
-	// 		function (resource) {
-	// 			resource.request = resource.request.replace(
-	// 				new RegExp(/\.js$/),
-	// 				''
-	// 			);
-	// 		}
-	// 	),
-	// ],
 };


### PR DESCRIPTION
This PR adds the ability to translate the labels in the vinyl player to different languages. Custom versions of the `media-chrome` web components are used to provide access to the labels in the player.

This PR also makes the following changes:

- Converst the package to type `module`.

Fixes: #13