### PR TITLE
feat: support custom colors for audio player

### DIFF
--- a/docs/planning.md
+++ b/docs/planning.md
@@ -8,6 +8,11 @@ Replicate the functionality of the audio block. Using the `audio` element.
 
 Add a custom UI that replicates the features of the standard `audio` element.
 
+### Color Supports
+
+-   [Block Supports - Color](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color)
+-   [Theme Supports - Color Palettes](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#block-color-palettes)
+
 ## Step Three
 
 Incrementally add features to expand the functionality.

--- a/languages/vinyl.pot
+++ b/languages/vinyl.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
-"POT-Creation-Date: 2024-05-27T14:00:03.421Z\n"
+"POT-Creation-Date: 2024-05-27T18:37:17.833Z\n"
 "PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
 "Last-Translator: codekraft, bitmachina <EMAIL>\n"
 "Language-Team: codekraft, bitmachina <EMAIL>\n"
@@ -50,21 +50,6 @@ msgstr ""
 msgid "Vinyl Audio requires WordPress 6.3 or later."
 msgstr ""
 
-#: src/web-components/vinyl-time-display.js:41
-msgid "Media not loaded, unknown time."
-msgstr ""
-
-# 1: current time, 2: total time
-#: src/web-components/vinyl-time-display.js:77
-msgid "%1$s of %2$s"
-msgstr ""
-
-# playback rate with multiplication symbol
-#: src/web-components/vinyl-playback-rate-button.js:58
-#: src/web-components/vinyl-playback-rate-button.js:76
-msgid "%sx"
-msgstr ""
-
 #: src/utils/time.js:37
 msgid "hour"
 msgstr ""
@@ -87,6 +72,21 @@ msgstr ""
 
 #: src/utils/time.js:46
 msgid "seconds"
+msgstr ""
+
+#: src/web-components/vinyl-time-display.js:41
+msgid "Media not loaded, unknown time."
+msgstr ""
+
+# 1: current time, 2: total time
+#: src/web-components/vinyl-time-display.js:77
+msgid "%1$s of %2$s"
+msgstr ""
+
+# playback rate with multiplication symbol
+#: src/web-components/vinyl-playback-rate-button.js:58
+#: src/web-components/vinyl-playback-rate-button.js:76
+msgid "%sx"
 msgstr ""
 
 #: src/labels/create-labels.js:5
@@ -199,27 +199,41 @@ msgstr ""
 msgid "playing live"
 msgstr ""
 
-#: src/audio/edit.tsx:152
+#: src/audio/edit.tsx:157
 msgid "Settings"
 msgstr ""
 
-#: src/audio/edit.tsx:155
+#: src/audio/edit.tsx:160
 msgid "Loop"
 msgstr ""
 
-#: src/audio/edit.tsx:175
+#: src/audio/edit.tsx:180
 msgid "Browser default"
 msgstr ""
 
-#: src/audio/edit.tsx:177
+#: src/audio/edit.tsx:182
 msgid "Auto"
 msgstr ""
 
-#: src/audio/edit.tsx:180
+#: src/audio/edit.tsx:185
 msgid "Metadata"
 msgstr ""
 
-#: src/audio/edit.tsx:209
+#: src/audio/edit.tsx:197
+msgid "Additional Colors"
+msgstr ""
+
+# color setting label of the track bar UI
+#: src/audio/edit.tsx:207
+msgid "Track Foreground"
+msgstr ""
+
+# color setting label of the track bar UI
+#: src/audio/edit.tsx:216
+msgid "Track Background"
+msgstr ""
+
+#: src/audio/edit.tsx:244
 msgid "Audio caption text"
 msgstr ""
 
@@ -236,12 +250,12 @@ msgstr ""
 msgid "Remove caption"
 msgstr ""
 
-#: src/audio/edit.tsx:160
+#: src/audio/edit.tsx:165
 msgctxt "noun; Audio block parameter"
 msgid "Preload"
 msgstr ""
 
-#: src/audio/edit.tsx:184
+#: src/audio/edit.tsx:189
 msgctxt "Preload value"
 msgid "None"
 msgstr ""

--- a/src/audio/block.json
+++ b/src/audio/block.json
@@ -41,6 +41,12 @@
 			"source": "attribute",
 			"selector": "audio",
 			"attribute": "preload"
+		},
+		"trackBarColor": {
+			"type": "string"
+		},
+		"trackBackgroundColor": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/src/audio/block.json
+++ b/src/audio/block.json
@@ -46,6 +46,11 @@
 	"supports": {
 		"anchor": true,
 		"align": true,
+		"color": {
+			"background": true,
+			"text": true,
+			"link": false
+		},
 		"spacing": {
 			"margin": true,
 			"padding": true

--- a/src/audio/edit.tsx
+++ b/src/audio/edit.tsx
@@ -5,6 +5,7 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
+	PanelColorSettings,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -39,7 +40,8 @@ function VinylEdit({
 	isSelected: isSingleSelected,
 	insertBlocksAfter,
 }: BlockEditProps<Attributes>) {
-	const { id, loop, preload, src } = attributes;
+	const { id, loop, preload, src, trackBarColor, trackBackgroundColor } =
+		attributes;
 
 	const isTemporaryAudio = !id && isBlobURL(src);
 
@@ -190,7 +192,32 @@ function VinylEdit({
 					/>
 				</PanelBody>
 			</InspectorControls>
+			<InspectorControls group="styles">
+				<PanelColorSettings
+					title={__('Additional Colors')}
+					colorSettings={[
+						{
+							value: trackBarColor,
+							onChange: (value) => {
+								setAttributes({ trackBarColor: value });
+							},
 
+							label:
+								/* translators: color setting label of the track bar UI */
+								__('Track Foreground', 'vinyl'),
+						},
+						{
+							value: trackBackgroundColor,
+							onChange: (value) => {
+								setAttributes({ trackBackgroundColor: value });
+							},
+							label:
+								/* translators: color setting label of the track bar UI */
+								__('Track Background', 'vinyl'),
+						},
+					]}
+				/>
+			</InspectorControls>
 			<figure {...blockProps}>
 				{/*
 					Disable the audio tag if the block is not selected

--- a/src/audio/edit.tsx
+++ b/src/audio/edit.tsx
@@ -28,6 +28,7 @@ import './editor.scss';
 import Caption from './edit/caption.js';
 import { Player } from './player/index.js';
 import type { Attributes } from './types';
+import useStyle from './use-style.js';
 
 const ALLOWED_MEDIA_TYPES = ['audio'];
 
@@ -114,6 +115,8 @@ function VinylEdit({
 		className: classes,
 	});
 
+	const style = useStyle(attributes);
+
 	if (!src) {
 		return (
 			<div {...blockProps}>
@@ -196,7 +199,12 @@ function VinylEdit({
 				*/}
 
 				<Disabled isDisabled={!isSingleSelected}>
-					<Player loop={loop} preload={preload} src={src} />
+					<Player
+						loop={loop}
+						preload={preload}
+						src={src}
+						style={style}
+					/>
 				</Disabled>
 
 				{isTemporaryAudio && <Spinner />}

--- a/src/audio/player/player.tsx
+++ b/src/audio/player/player.tsx
@@ -20,7 +20,7 @@ export default function Player({ loop, preload, src, style }: Props) {
 	return (
 		<VinylController audio={true} autohide="-1" style={style}>
 			<audio slot="media" src={src} preload={preload} loop={loop} />
-			<VinylControlBar>
+			<VinylControlBar className="vinyl__control-bar--normal">
 				<VinylSeekBackwardButton></VinylSeekBackwardButton>
 				<VinylPlayButton></VinylPlayButton>
 				<VinylSeekForwardButton></VinylSeekForwardButton>

--- a/src/audio/player/player.tsx
+++ b/src/audio/player/player.tsx
@@ -1,6 +1,7 @@
 import {
 	VinylController,
 	VinylControlBar,
+	VinylDurationDisplay,
 	VinylMuteButton,
 	VinylPlayButton,
 	VinylPlaybackRateButton,
@@ -8,38 +9,26 @@ import {
 	VinylSeekForwardButton,
 	VinylTimeRange,
 	VinylTimeDisplay,
-	VinylVolumeRange,
 } from '../../react/index.js';
 import type { Attributes } from '../types';
 
-type Props = Omit<Attributes, 'caption' | 'id'> & {
+type Props = Pick<Attributes, 'loop' | 'preload' | 'src'> & {
 	style?: React.CSSProperties;
 };
 
 export default function Player({ loop, preload, src, style }: Props) {
 	return (
-		<VinylController
-			audio={true}
-			autohide="-1"
-			className="vinyl__player"
-			style={style}
-		>
+		<VinylController audio={true} autohide="-1" style={style}>
 			<audio slot="media" src={src} preload={preload} loop={loop} />
-			<VinylControlBar className="vinyl__control-bar">
-				<div className="vinyl__media-controls">
-					<VinylPlayButton></VinylPlayButton>
-					<VinylSeekBackwardButton></VinylSeekBackwardButton>
-					<VinylSeekForwardButton></VinylSeekForwardButton>
-				</div>
-				<div className="vinyl__media-range">
-					<VinylTimeRange></VinylTimeRange>
-					<VinylTimeDisplay showDuration></VinylTimeDisplay>
-				</div>
-				<div className="vinyl__media-sound">
-					<VinylPlaybackRateButton></VinylPlaybackRateButton>
-					<VinylMuteButton></VinylMuteButton>
-					<VinylVolumeRange></VinylVolumeRange>
-				</div>
+			<VinylControlBar>
+				<VinylSeekBackwardButton></VinylSeekBackwardButton>
+				<VinylPlayButton></VinylPlayButton>
+				<VinylSeekForwardButton></VinylSeekForwardButton>
+				<VinylTimeDisplay></VinylTimeDisplay>
+				<VinylTimeRange className="vinyl__time-range"></VinylTimeRange>
+				<VinylDurationDisplay></VinylDurationDisplay>
+				<VinylPlaybackRateButton></VinylPlaybackRateButton>
+				<VinylMuteButton></VinylMuteButton>
 			</VinylControlBar>
 		</VinylController>
 	);

--- a/src/audio/player/player.tsx
+++ b/src/audio/player/player.tsx
@@ -12,11 +12,18 @@ import {
 } from '../../react/index.js';
 import type { Attributes } from '../types';
 
-type Props = Omit<Attributes, 'caption' | 'id'>;
+type Props = Omit<Attributes, 'caption' | 'id'> & {
+	style?: React.CSSProperties;
+};
 
-export default function Player({ loop, preload, src }: Props) {
+export default function Player({ loop, preload, src, style }: Props) {
 	return (
-		<VinylController audio={true} autohide="-1" className="vinyl__player">
+		<VinylController
+			audio={true}
+			autohide="-1"
+			className="vinyl__player"
+			style={style}
+		>
 			<audio slot="media" src={src} preload={preload} loop={loop} />
 			<VinylControlBar className="vinyl__control-bar">
 				<div className="vinyl__media-controls">

--- a/src/audio/save.tsx
+++ b/src/audio/save.tsx
@@ -15,17 +15,24 @@ import {
 } from '../react/index.js';
 
 import type { Attributes } from './types';
+import { computeStyle } from './use-style.js';
 
 export default function Save({ attributes }: BlockSaveProps<Attributes>) {
 	const { loop, preload, src } = attributes;
 
+	const blockProps = useBlockProps.save();
+
+	// Not using a hook here because the save function should be static.
+	const style = computeStyle(attributes);
+
 	return (
 		src && (
-			<figure {...useBlockProps.save()}>
+			<figure {...blockProps}>
 				<VinylController
 					audio={true}
 					autohide="-1"
 					className="vinyl__player"
+					style={style}
 				>
 					<audio
 						slot="media"

--- a/src/audio/save.tsx
+++ b/src/audio/save.tsx
@@ -1,19 +1,7 @@
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import type { BlockSaveProps } from '@wordpress/blocks';
 
-import {
-	VinylController,
-	VinylControlBar,
-	VinylMuteButton,
-	VinylPlayButton,
-	VinylPlaybackRateButton,
-	VinylSeekBackwardButton,
-	VinylSeekForwardButton,
-	VinylTimeRange,
-	VinylTimeDisplay,
-	VinylVolumeRange,
-} from '../react/index.js';
-
+import { Player } from './player/index.js';
 import type { Attributes } from './types';
 import { computeStyle } from './use-style.js';
 
@@ -28,35 +16,7 @@ export default function Save({ attributes }: BlockSaveProps<Attributes>) {
 	return (
 		src && (
 			<figure {...blockProps}>
-				<VinylController
-					audio={true}
-					autohide="-1"
-					className="vinyl__player"
-					style={style}
-				>
-					<audio
-						slot="media"
-						src={src}
-						preload={preload}
-						loop={loop}
-					/>
-					<VinylControlBar className="vinyl__control-bar">
-						<div className="vinyl__media-controls">
-							<VinylPlayButton></VinylPlayButton>
-							<VinylSeekBackwardButton></VinylSeekBackwardButton>
-							<VinylSeekForwardButton></VinylSeekForwardButton>
-						</div>
-						<div className="vinyl__media-range">
-							<VinylTimeRange></VinylTimeRange>
-							<VinylTimeDisplay showDuration></VinylTimeDisplay>
-						</div>
-						<div className="vinyl__media-sound">
-							<VinylPlaybackRateButton></VinylPlaybackRateButton>
-							<VinylMuteButton></VinylMuteButton>
-							<VinylVolumeRange></VinylVolumeRange>
-						</div>
-					</VinylControlBar>
-				</VinylController>
+				<Player loop={loop} preload={preload} src={src} style={style} />
 				{hasCaption(attributes) && (
 					<RichText.Content
 						tagName="figcaption"

--- a/src/audio/style.scss
+++ b/src/audio/style.scss
@@ -1,6 +1,15 @@
 .wp-block-vinyl-audio {
 	--vinyl-background-color: var(--wp--preset--color--base, transparent);
 	--vinyl-text-color: var(--wp--preset--color--contrast, #000);
+	--vinyl-track-bar-color: var(--vinyl-text-color);
+	--vinyl-track-background-color: rgb(0 0 0 / 0.02);
+
+	--vinyl-ring-shadow: 0 0 #0000;
+	--vinyl-ring-offset-shadow: 0 0 #0000;
+	--vinyl-shadow-color: rgb(0 0 0 / 0.05);
+	--vinyl-shadow-colored: 0 20px 25px -5px var(--vinyl-shadow-color),
+		0 8px 10px -6px var(--vinyl-shadow-color);
+	--vinyl-shadow: var(--vinyl-shadow-colored);
 
 	/* This block has customizable padding, border-box makes that more predictable. */
 	box-sizing: border-box;
@@ -21,6 +30,39 @@
 
 		/* The primary color is used for --media-text-color and --media-icon-color. */
 		--media-primary-color: var(--vinyl-text-color);
+
+		box-shadow: var(--vinyl-ring-offset-shadow, 0 0 #0000),
+			var(--vinyl-ring-shadow, 0 0 #0000), var(--vinyl-shadow);
+	}
+
+	vinyl-time-range {
+		--media-range-track-background: var(
+			--vinyl-track-background-color,
+			transparent
+		);
+		--media-time-buffered-color: rgb(0 0 0 / 0.02);
+		--media-range-bar-color: var(--vinyl-track-bar-color);
+		--media-range-track-border-radius: 4px;
+		--media-range-track-height: 0.5rem;
+		--media-range-thumb-background: var(--media-primary-color);
+		--media-range-thumb-box-shadow: 0 0 0 2px var(--media-background-color);
+		--media-range-thumb-width: 0.25rem;
+		--media-range-thumb-height: 1rem;
+		--media-preview-time-text-shadow: transparent;
+	}
+
+	vinyl-volume-range {
+		--media-range-track-background: var(
+			--vinyl-track-background-color,
+			transparent
+		);
+		--media-range-bar-color: var(--vinyl-track-bar-color);
+		--media-range-track-border-radius: 4px;
+		--media-range-track-height: 0.5rem;
+		--media-range-thumb-background: var(--media-primary-color);
+		--media-range-thumb-box-shadow: 0 0 0 2px var(--media-background-color);
+		--media-range-thumb-width: 0.25rem;
+		--media-range-thumb-height: 1rem;
 	}
 
 	/* Show full-width when not aligned. */

--- a/src/audio/style.scss
+++ b/src/audio/style.scss
@@ -5,7 +5,11 @@
 	--vinyl-track-background-color: rgb(0 0 0 / 0.02);
 
 	--vinyl-ring-shadow: 0 0 #0000;
+	--vinyl-ring-inset: ;
+	--vinyl-ring-offset-color: var(--vinyl-background-color);
 	--vinyl-ring-offset-shadow: 0 0 #0000;
+	--vinyl-ring-offset-width: 0px;
+	--vinyl-ring-color: var(--vinyl-text-color);
 	--vinyl-shadow-color: rgb(0 0 0 / 0.05);
 	--vinyl-shadow-colored: 0 20px 25px -5px var(--vinyl-shadow-color),
 		0 8px 10px -6px var(--vinyl-shadow-color);
@@ -24,12 +28,21 @@
 	}
 
 	vinyl-controller {
-		--media-background-color: var(--vinyl-background-color);
+		--media-background-color: transparent;
 		--media-control-background: var(--vinyl-background-color);
 		--media-control-hover-background: transparent;
 
 		/* The primary color is used for --media-text-color and --media-icon-color. */
 		--media-primary-color: var(--vinyl-text-color);
+		// --media-icon-color: none;
+		// --media-button-icon-height: 2rem;
+		// --media-button-icon-width: 2rem;
+		// --media-button-padding: 0rem;
+
+		display: block;
+		container-type: inline-size;
+
+		width: 100%;
 
 		box-shadow: var(--vinyl-ring-offset-shadow, 0 0 #0000),
 			var(--vinyl-ring-shadow, 0 0 #0000), var(--vinyl-shadow);
@@ -44,8 +57,11 @@
 		--media-range-bar-color: var(--vinyl-track-bar-color);
 		--media-range-track-border-radius: 4px;
 		--media-range-track-height: 0.5rem;
-		--media-range-thumb-background: var(--media-primary-color);
-		--media-range-thumb-box-shadow: 0 0 0 2px var(--media-background-color);
+		--media-range-thumb-background: var(
+			--vinyl-track-bar-color,
+			--media-primary-color
+		);
+		--media-range-thumb-box-shadow: 0 0 0 2px var(--vinyl-background-color);
 		--media-range-thumb-width: 0.25rem;
 		--media-range-thumb-height: 1rem;
 		--media-preview-time-text-shadow: transparent;
@@ -59,7 +75,10 @@
 		--media-range-bar-color: var(--vinyl-track-bar-color);
 		--media-range-track-border-radius: 4px;
 		--media-range-track-height: 0.5rem;
-		--media-range-thumb-background: var(--media-primary-color);
+		--media-range-thumb-background: var(
+			--vinyl-track-bar-color,
+			--media-primary-color
+		);
 		--media-range-thumb-box-shadow: 0 0 0 2px var(--media-background-color);
 		--media-range-thumb-width: 0.25rem;
 		--media-range-thumb-height: 1rem;
@@ -80,64 +99,85 @@
 		}
 	}
 
-	.vinyl__control-bar {
-		display: grid;
-		grid-template-rows: [start top] auto [top bottom] auto [bottom end];
-		grid-template-columns: [start controls] 1fr [controls sound] auto [sound end];
-		align-items: center;
+	.vinyl__control-bar--normal {
+		--vinyl-ring-offset-shadow: var(--vinyl-ring-inset) 0 0 0
+			var(--vinyl-ring-offset-width) var(--vinyl-ring-offset-color);
+		--vinyl-ring-shadow: var(--vinyl-ring-inset) 0 0 0
+			calc(1px + var(--vinyl-ring-offset-width)) var(--vinyl-ring-color);
 
-		@media (min-width: 650px) {
-			grid-template-columns: [start controls] auto [controls range] 1fr [range sound] auto [sound end];
-			grid-template-rows: 1fr;
-			grid-column: range / range;
-		}
-	}
-
-	.vinyl__media-range {
-		--media-range-padding-left: 20px;
-
-		grid-row: top / top;
-		grid-column: start / end;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
 
-		vinyl-time-range {
-			width: 100%;
+		width: 100%;
+		height: 4rem;
+
+		padding-left: 1rem;
+		padding-right: 1rem;
+
+		background-color: var(--media-background-color);
+
+		border-radius: 0.375rem;
+
+		// box-shadow: var(--vinyl-ring-offset-shadow), var(--vinyl-ring-shadow),
+		// 	var(--vinyl-shadow, 0 0 #0000);
+	}
+
+	.vinyl__time-range {
+		width: 100%;
+	}
+
+	.vinyl__button {
+		width: 2rem;
+		height: 2rem;
+
+		padding: 0;
+		border-radius: 9999px;
+		outline: none;
+
+		&:focus {
+			--vinyl-ring-offset-shadow: var(--vinyl-ring-inset) 0 0 0
+				var(--vinyl-ring-offset-width) var(--vinyl-ring-color);
+			--vinyl-ring-shadow: var(--vinyl-ring-inset) 0 0 0
+				calc(2px + var(--vinyl-ring-offset-width))
+				var(--vinyl-ring-color);
+			--vinyl-shadow: 0 0 #0000;
+
+			outline: none;
+			box-shadow: var(--vinyl-ring-offset-shadow),
+				var(--vinyl-ring-shadow), var(--vinyl-shadow, 0 0 #0000);
 		}
 
-		@media (min-width: 650px) {
-			--media-range-padding-left: 10px;
+		&--play {
+			--vinyl-ring-offset-width: 2px;
 
-			grid-column: range / range;
-			grid-row: 1;
+			margin-right: 0.75rem;
+			margin-left: 0.75rem;
+
+			padding: 0.5rem;
+
+			width: 2.5rem;
+			height: 2.5rem;
 		}
 	}
 
-	.vinyl__media-controls {
-		grid-column: controls / controls;
-		grid-row: bottom / bottom;
-		display: flex;
-		align-items: flex-end;
+	.vinyl__icon {
+		width: 1.75rem;
+		height: 1.75rem;
 
-		@media (min-width: 650px) {
-			grid-column: controls / controls;
-			grid-row: 1;
-			align-items: center;
-		}
+		fill: none;
+		stroke: var(--media-primary-color);
 	}
 
-	.vinyl__media-sound {
-		grid-column: sound / sound;
-		grid-row: bottom / bottom;
-		display: flex;
-		justify-content: flex-end;
-		align-items: flex-end;
+	.vinyl__wrapper {
+		background-color: transparent !important;
+	}
 
-		@media (min-width: 650px) {
-			grid-column: sound / sound;
-			grid-row: 1;
-			align-items: center;
-		}
+	.vinyl--round {
+		border-radius: 9999px;
+	}
+
+	.vinyl--rounded-md {
+		border-radius: 0.375rem;
 	}
 }

--- a/src/audio/style.scss
+++ b/src/audio/style.scss
@@ -1,4 +1,7 @@
 .wp-block-vinyl-audio {
+	--vinyl-background-color: var(--wp--preset--color--base, transparent);
+	--vinyl-text-color: var(--wp--preset--color--contrast, #000);
+
 	/* This block has customizable padding, border-box makes that more predictable. */
 	box-sizing: border-box;
 
@@ -9,6 +12,15 @@
 	 */
 	figcaption {
 		margin-top: 0.5em;
+	}
+
+	vinyl-controller {
+		--media-background-color: var(--vinyl-background-color);
+		--media-control-background: var(--vinyl-background-color);
+		--media-control-hover-background: transparent;
+
+		/* The primary color is used for --media-text-color and --media-icon-color. */
+		--media-primary-color: var(--vinyl-text-color);
 	}
 
 	/* Show full-width when not aligned. */

--- a/src/audio/types.ts
+++ b/src/audio/types.ts
@@ -19,6 +19,16 @@ export interface Attributes {
 	backgroundColor?: string;
 
 	/**
+	 * The `--media-range-bar-color` CSS custom property value.
+	 */
+	trackBarColor?: string;
+
+	/**
+	 * The `--media-range-track-background` CSS custom property value.
+	 */
+	trackBackgroundColor?: string;
+
+	/**
 	 * The block's style settings.
 	 */
 	style?: Style;

--- a/src/audio/types.ts
+++ b/src/audio/types.ts
@@ -1,4 +1,5 @@
 import type { Transform } from '@wordpress/blocks';
+import type { Style } from '@wordpress/style-engine/build-types/types';
 
 export interface Attributes {
 	caption?: string;
@@ -6,6 +7,21 @@ export interface Attributes {
 	loop?: boolean;
 	src?: string;
 	preload?: string;
+
+	/**
+	 * Set by the color block support, if a text color is set.
+	 */
+	textColor?: string;
+
+	/**
+	 * Set by the color block support, if a background color is set.
+	 */
+	backgroundColor?: string;
+
+	/**
+	 * The block's style settings.
+	 */
+	style?: Style;
 }
 
 /**

--- a/src/audio/use-style.ts
+++ b/src/audio/use-style.ts
@@ -6,11 +6,7 @@ import { Attributes } from './types';
  * @param attributes The audio block attributes.
  */
 export default function useStyle(attributes: Attributes): React.CSSProperties {
-	const style = useMemo(
-		() => computeStyle(attributes),
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[attributes.textColor, attributes.backgroundColor, attributes.style]
-	);
+	const style = useMemo(() => computeStyle(attributes), [attributes]);
 
 	return style;
 }
@@ -32,5 +28,28 @@ export function computeStyle(attributes: Attributes) {
 		result['--vinyl-text-color'] = attributes.style.color.text;
 	}
 
+	if (attributes.trackBarColor) {
+		if (isColorValue(attributes.trackBarColor)) {
+			result['--vinyl-track-bar-color'] = attributes.trackBarColor;
+		} else {
+			result['--vinyl-track-bar-color'] =
+				`var(--wp--preset--color--${attributes.trackBarColor})`;
+		}
+	}
+
+	if (attributes.trackBackgroundColor) {
+		if (isColorValue(attributes.trackBackgroundColor)) {
+			result['--vinyl-track-background-color'] =
+				attributes.trackBackgroundColor;
+		} else {
+			result['--vinyl-track-background-color'] =
+				`var(--wp--preset--color--${attributes.trackBackgroundColor})`;
+		}
+	}
+
 	return result;
+}
+
+function isColorValue(value: string) {
+	return /^#[0-9a-f]{3,6}$/i.test(value);
 }

--- a/src/audio/use-style.ts
+++ b/src/audio/use-style.ts
@@ -1,0 +1,36 @@
+import { useMemo } from '@wordpress/element';
+
+import { Attributes } from './types';
+
+/**
+ * @param attributes The audio block attributes.
+ */
+export default function useStyle(attributes: Attributes): React.CSSProperties {
+	const style = useMemo(
+		() => computeStyle(attributes),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[attributes.textColor, attributes.backgroundColor, attributes.style]
+	);
+
+	return style;
+}
+
+export function computeStyle(attributes: Attributes) {
+	const result: React.CSSProperties = {};
+
+	if (attributes.backgroundColor) {
+		result['--vinyl-background-color'] =
+			`var(--wp--preset--color--${attributes.backgroundColor})`;
+	} else if (attributes.style?.color?.background) {
+		result['--vinyl-background-color'] = attributes.style.color.background;
+	}
+
+	if (attributes.textColor) {
+		result['--vinyl-text-color'] =
+			`var(--wp--preset--color--${attributes.textColor})`;
+	} else if (attributes.style?.color?.text) {
+		result['--vinyl-text-color'] = attributes.style.color.text;
+	}
+
+	return result;
+}

--- a/src/media-chrome.js
+++ b/src/media-chrome.js
@@ -1,6 +1,7 @@
 // Only import the components we need.
 import './web-components/vinyl-controller.js';
 import './web-components/vinyl-control-bar.js';
+import './web-components/vinyl-duration-display.js';
 import './web-components/vinyl-time-range.js';
 import './web-components/vinyl-time-display.js';
 import './web-components/vinyl-volume-range.js';

--- a/src/react/index.d.ts
+++ b/src/react/index.d.ts
@@ -33,6 +33,9 @@ export { VinylControlBar };
 declare const VinylController: GenericForwardRef;
 export { VinylController };
 
+declare const VinylDurationDisplay: GenericForwardRef;
+export { VinylDurationDisplay };
+
 declare const VinylMuteButton: GenericForwardRef;
 export { VinylMuteButton };
 

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -27,6 +27,13 @@ const VinylController = React.forwardRef(({ children = [], ...props }, ref) => {
 export { VinylController };
 
 /** @type { import("react").HTMLElement } */
+const VinylDurationDisplay = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('vinyl-duration-display', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
+});
+
+export { VinylDurationDisplay };
+
+/** @type { import("react").HTMLElement } */
 const VinylMuteButton = React.forwardRef(({ children = [], ...props }, ref) => {
   return React.createElement('vinyl-mute-button', toNativeProps({ ...props, suppressHydrationWarning: true, ref }), children);
 });

--- a/src/web-components/index.js
+++ b/src/web-components/index.js
@@ -1,6 +1,7 @@
 export { default as VinylContainer } from './vinyl-container.js';
 export { default as VinylControlBar } from './vinyl-control-bar.js';
 export { default as VinylController } from './vinyl-controller.js';
+export { default as VinylDurationDisplay } from './vinyl-duration-display.js';
 export { default as VinylMuteButton } from './vinyl-mute-button.js';
 export { default as VinylPlayButton } from './vinyl-play-button.js';
 export { default as VinylPlaybackRateButton } from './vinyl-playback-rate-button.js';

--- a/src/web-components/vinyl-duration-display.js
+++ b/src/web-components/vinyl-duration-display.js
@@ -1,0 +1,55 @@
+import { MediaUIAttributes } from 'media-chrome/dist/constants.js';
+import { MediaTextDisplay } from 'media-chrome/dist/media-text-display.js';
+
+import { getNumericAttr, setNumericAttr } from '../utils/element-utils.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+import { formatTime } from '../utils/time.js';
+
+// Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
+
+/**
+ * @attr {string} mediaduration - (read-only) Set to the media duration.
+ *
+ * @cssproperty [--media-duration-display-display = inline-flex] - `display` property of display.
+ */
+class VinylDurationDisplay extends MediaTextDisplay {
+	/** @type {HTMLSlotElement} */
+	#slot;
+
+	static get observedAttributes() {
+		return [...super.observedAttributes, MediaUIAttributes.MEDIA_DURATION];
+	}
+
+	constructor() {
+		super();
+		this.#slot = this.shadowRoot.querySelector('slot');
+		this.#slot.textContent = formatTime(0);
+	}
+
+	attributeChangedCallback(attrName, oldValue, newValue) {
+		if (attrName === MediaUIAttributes.MEDIA_DURATION) {
+			this.#slot.textContent = formatTime(+newValue);
+		}
+		super.attributeChangedCallback(attrName, oldValue, newValue);
+	}
+
+	/**
+	 * @type {number | undefined} In seconds
+	 */
+	get mediaDuration() {
+		return getNumericAttr(this, MediaUIAttributes.MEDIA_DURATION);
+	}
+
+	set mediaDuration(time) {
+		setNumericAttr(this, MediaUIAttributes.MEDIA_DURATION, time);
+	}
+}
+
+if (!globalThis.customElements.get('vinyl-duration-display')) {
+	globalThis.customElements.define(
+		'vinyl-duration-display',
+		VinylDurationDisplay
+	);
+}
+
+export default VinylDurationDisplay;


### PR DESCRIPTION
This commit adds block supports for color customization.

The block editor color palette is used to select the colors. The colors are stored in the block attributes, though are applied using inline styles of custom CSS properties. This allows the custom colors to be applied to the shadow DOM of the `media-chrome` web components.

<img width="1074" alt="track-foreground" src="https://github.com/wp-blocks/vinyl/assets/20690965/4ae6f893-90c1-4891-9b36-275543e2f29a">

Fixes: #11